### PR TITLE
Add opencode-morph-fast-apply plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@
 |[opencode-gemini-auth](https://github.com/jenslys/opencode-gemini-auth)|![GitHub Repo stars](https://badgen.net/github/stars/jenslys/opencode-gemini-auth)|Authenticate the Opencode CLI with your Google account so you can use your existing Gemini plan and its included quota instead of API billing|
 |[opencode-direnv](https://github.com/simonwjackson/opencode-direnv)|![GitHub Repo stars](https://badgen.net/github/stars/simonwjackson/opencode-direnv)|Automatically loads direnv environment variables at session start. Perfect for Nix flakes and project-specific environments.|
 |[oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)|![GitHub Repo stars](https://badgen.net/github/stars/code-yeongyu/oh-my-opencode)|Background agents, pre-built tools (LSP/AST/MCP), curated agents, and a Claude Code compatible layer.|
+|[opencode-morph-fast-apply](https://github.com/JRedeker/opencode-morph-fast-apply)|![GitHub Repo stars](https://badgen.net/github/stars/JRedeker/opencode-morph-fast-apply)|10x faster code editing with Morph Fast Apply API and lazy edit markers.|
 ➡️ **[Suggest a new Plugin in our Discussions!](https://github.com/awesome-opencode/awesome-opencode/discussions/categories/plugins)**
 
 ## Themes


### PR DESCRIPTION
## Summary

Adds [opencode-morph-fast-apply](https://github.com/JRedeker/opencode-morph-fast-apply) to the Plugins section.

## About the Plugin

OpenCode plugin that integrates [Morph's Fast Apply API](https://morphllm.com) for faster code editing:

- **10,500+ tokens/sec** code editing speed
- **Lazy edit markers** (`// ... existing code ...`) - no exact string matching needed  
- **Unified diff output** with context for easy review
- **Graceful fallback** - suggests native `edit` tool on API failure

This provides a lighter-weight alternative to running Morph as an MCP server.