### PR TITLE
Add opencode-shell-strategy plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@
 |[opencode-gemini-auth](https://github.com/jenslys/opencode-gemini-auth)|![GitHub Repo stars](https://badgen.net/github/stars/jenslys/opencode-gemini-auth)|Authenticate the Opencode CLI with your Google account so you can use your existing Gemini plan and its included quota instead of API billing|
 |[opencode-direnv](https://github.com/simonwjackson/opencode-direnv)|![GitHub Repo stars](https://badgen.net/github/stars/simonwjackson/opencode-direnv)|Automatically loads direnv environment variables at session start. Perfect for Nix flakes and project-specific environments.|
 |[oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)|![GitHub Repo stars](https://badgen.net/github/stars/code-yeongyu/oh-my-opencode)|Background agents, pre-built tools (LSP/AST/MCP), curated agents, and a Claude Code compatible layer.|
+|[opencode-shell-strategy](https://github.com/JRedeker/opencode-shell-strategy)|![GitHub Repo stars](https://badgen.net/github/stars/JRedeker/opencode-shell-strategy)|Instructions for non-interactive shell commands - prevents hangs from TTY-dependent operations.|
 ➡️ **[Suggest a new Plugin in our Discussions!](https://github.com/awesome-opencode/awesome-opencode/discussions/categories/plugins)**
 
 ## Themes


### PR DESCRIPTION
## Summary

Adds [opencode-shell-strategy](https://github.com/JRedeker/opencode-shell-strategy) to the Plugins section.

## About the Plugin

Instructions file that teaches LLMs how to avoid interactive shell commands that hang in OpenCode's non-TTY environment.

Covers:
- **Package managers**: `npm init -y`, `apt-get install -y`, `pip install --no-input`
- **Git operations**: `git commit -m`, `git merge --no-edit`, avoid `git add -p`
- **System commands**: `rm -f`, `ssh -o BatchMode=yes`, `unzip -o`
- **Banned commands**: editors (`vim`, `nano`), pagers (`less`, `more`, `man`)

Particularly useful for models less familiar with headless CI/CD environments.