### PR TITLE
Add plannotator plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@
 |[opencode-gemini-auth](https://github.com/jenslys/opencode-gemini-auth)|![GitHub Repo stars](https://badgen.net/github/stars/jenslys/opencode-gemini-auth)|Authenticate the Opencode CLI with your Google account so you can use your existing Gemini plan and its included quota instead of API billing|
 |[opencode-direnv](https://github.com/simonwjackson/opencode-direnv)|![GitHub Repo stars](https://badgen.net/github/stars/simonwjackson/opencode-direnv)|Automatically loads direnv environment variables at session start. Perfect for Nix flakes and project-specific environments.|
 |[oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)|![GitHub Repo stars](https://badgen.net/github/stars/code-yeongyu/oh-my-opencode)|Background agents, pre-built tools (LSP/AST/MCP), curated agents, and a Claude Code compatible layer.|
+|[plannotator](https://github.com/backnotprop/plannotator)|![GitHub Repo stars](https://badgen.net/github/stars/backnotprop/plannotator)|Interactive plan review with visual annotation and private/offline sharing.|
 |[@openspoon/subtask2](https://github.com/spoons-and-mirrors/subtask2)|![GitHub Repo stars](https://badgen.net/github/stars/spoons-and-mirrors/subtask2)|Extend opencode /commands into a powerful orchestration system with granular flow control.|
 ➡️ **[Suggest a new Plugin in our Discussions!](https://github.com/awesome-opencode/awesome-opencode/discussions/categories/plugins)**
 


### PR DESCRIPTION
## Summary

Adding [plannotator](https://github.com/backnotprop/plannotator) to the Plugins section.

**Description:** Interactive plan review with visual annotation and private/offline sharing.

## About Plannotator

Plannotator is a plan review UI for AI coding agents that intercepts plan mode, letting users:
- Visually annotate plans with comments, deletions, replacements
- Share plans via URL (compressed, offline-first)
- Integrate with Obsidian and Bear for note-taking
- Save plans locally with configurable paths

Works with both Claude Code and OpenCode.

Already listed on the [OpenCode website](https://opencode.ai/plugins).