### PR TITLE
plugin: add octto

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@
 |[opencode-direnv](https://github.com/simonwjackson/opencode-direnv)|![GitHub Repo stars](https://badgen.net/github/stars/simonwjackson/opencode-direnv)|Automatically loads direnv environment variables at session start. Perfect for Nix flakes and project-specific environments.|
 |[oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)|![GitHub Repo stars](https://badgen.net/github/stars/code-yeongyu/oh-my-opencode)|Background agents, pre-built tools (LSP/AST/MCP), curated agents, and a Claude Code compatible layer.|
 |[@openspoon/subtask2](https://github.com/spoons-and-mirrors/subtask2)|![GitHub Repo stars](https://badgen.net/github/stars/spoons-and-mirrors/subtask2)|Extend opencode /commands into a powerful orchestration system with granular flow control.|
+|[octto](https://github.com/vtemian/octto)|![GitHub Repo stars](https://badgen.net/github/stars/vtemian/octto)|Interactive browser UI for AI brainstorming with multi-question forms, parallel exploration branches, and visual feedback.|
 ➡️ **[Suggest a new Plugin in our Discussions!](https://github.com/awesome-opencode/awesome-opencode/discussions/categories/plugins)**
 
 ## Themes


### PR DESCRIPTION
## Summary

- Adds [octto](https://github.com/vtemian/octto) to the Plugins section

## Description

octto is an interactive browser UI for AI brainstorming that replaces terminal typing with visual interactions:

- **14 rich question types** - pick_one, pick_many, sliders, code editors, diff views, etc.
- **Parallel exploration branches** - Split requests into 2-4 branches, answer in any order
- **Live updates** - Questions appear dynamically as you answer
- **Visual plan review** - Final plan rendered as reviewable sections
- **Agent orchestration** - bootstrapper, probe, and octto agents work together

Turns 10 minutes of terminal typing into 2 minutes of clicking.