### PR TITLE
docs: add OCX and KDCO OpenCode plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@
 |[oc-manager](https://github.com/kcrommett/oc-manager)|![GitHub Repo stars](https://badgen.net/github/stars/kcrommett/oc-manager)|Terminal UI for inspecting, filtering, and pruning OpenCode metadata stored on disk. The app is written in TypeScript, runs on Bun, and renders with @opentui/react.|
 |[beads](https://github.com/steveyegge/beads)|![GitHub Repo stars](https://badgen.net/github/stars/steveyegge/beads)|Steve Yegge's project/task management system for agents (with beads_viewer UI)|
 |[opencode-ddev](https://github.com/JUVOJustin/opencode-ddev)|![GitHub Repo stars](https://badgen.net/github/stars/JUVOJustin/opencode-ddev)|Wraps bash commands to execute inside the DDEV container (Docker-based PHP development environments).|
-|[ocx](https://github.com/kdcokenny/ocx)|![GitHub Repo stars](https://badgen.net/github/stars/kdcokenny/ocx)|The missing package manager for OpenCode extensions – ShadCN model with Ghost Mode.|
+|[ocx](https://github.com/kdcokenny/ocx)|![GitHub Repo stars](https://badgen.net/github/stars/kdcokenny/ocx)|OpenCode extension manager with Ghost Mode for portable, isolated profiles. Work anywhere with your config.|
 ➡️ **[Suggest a new Project in our Discussions!](https://github.com/awesome-opencode/awesome-opencode/discussions/categories/projects)**
 
 ## Resources


### PR DESCRIPTION
## Summary

Adds 5 community projects from the KDCO ecosystem.

### Projects
- **[ocx](https://github.com/kdcokenny/ocx)** – The missing package manager for OpenCode extensions – ShadCN model with Ghost Mode

### Plugins
- **[opencode-background-agents](https://github.com/kdcokenny/opencode-background-agents)** – Claude Code-style background agents with async delegation and context persistence
- **[opencode-notify](https://github.com/kdcokenny/opencode-notify)** – Native OS notifications for OpenCode – know when tasks complete
- **[opencode-workspace](https://github.com/kdcokenny/opencode-workspace)** – Bundled multi-agent orchestration harness – 16 components, one install
- **[opencode-worktree](https://github.com/kdcokenny/opencode-worktree)** – Zero-friction git worktrees for OpenCode. Auto-spawns terminals, syncs files, cleans up on exit

All projects include the required affiliation disclaimer.