### PR TITLE
docs: add cc-safety-net to Plugins section

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@
 |[plannotator](https://github.com/backnotprop/plannotator)|![GitHub Repo stars](https://badgen.net/github/stars/backnotprop/plannotator)|Interactive plan review with visual annotation and private/offline sharing.|
 |[@openspoon/subtask2](https://github.com/spoons-and-mirrors/subtask2)|![GitHub Repo stars](https://badgen.net/github/stars/spoons-and-mirrors/subtask2)|Extend opencode /commands into a powerful orchestration system with granular flow control.|
 |[opencode-ralph-wiggum](https://github.com/Th0rgal/opencode-ralph-wiggum)|![GitHub Repo stars](https://badgen.net/github/stars/Th0rgal/opencode-ralph-wiggum)|Iterative AI development loops with self-correcting agents. Based on the Ralph Wiggum technique.|
+|[cc-safety-net](https://github.com/kenryu42/claude-code-safety-net)|![GitHub Repo stars](https://badgen.net/github/stars/kenryu42/claude-code-safety-net)|Block destructive git and filesystem commands before they execute.|
 ➡️ **[Suggest a new Plugin in our Discussions!](https://github.com/awesome-opencode/awesome-opencode/discussions/categories/plugins)**
 
 ## Themes


### PR DESCRIPTION
Hello, this PR adds a new plugin to the Plugins section.

## `cc-safety-net`

This plugin acts as a **safety net for AI coding agents**, catching destructive git and filesystem commands before they execute. It provides semantic command analysis that goes beyond simple prefix matching—parsing arguments, understanding flag combinations, recursively analyzing shell wrappers, and distinguishing safe operations from dangerous ones.

**Key features:**

- Blocks destructive git commands (`git reset --hard`, `git push --force`, `git checkout --`, etc.)
- Prevents dangerous filesystem operations (`rm -rf` outside cwd, root/home deletion)
- Detects shell wrappers (`bash -c`, `sh -c`) and interpreter one-liners (`python -c`)
- Supports custom blocking rules via `.safety-net.json`
- Includes audit logging and secret redaction

**npm:** [`cc-safety-net`](https://www.npmjs.com/package/cc-safety-net)
Read more about it [here](https://github.com/kenryu42/claude-code-safety-net).

Thanks.