### PR TITLE
Add opencode-canvas plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@
 |[plannotator](https://github.com/backnotprop/plannotator)|![GitHub Repo stars](https://badgen.net/github/stars/backnotprop/plannotator)|Interactive plan review with visual annotation and private/offline sharing.|
 |[@openspoon/subtask2](https://github.com/spoons-and-mirrors/subtask2)|![GitHub Repo stars](https://badgen.net/github/stars/spoons-and-mirrors/subtask2)|Extend opencode /commands into a powerful orchestration system with granular flow control.|
 |[opencode-ralph-wiggum](https://github.com/Th0rgal/opencode-ralph-wiggum)|![GitHub Repo stars](https://badgen.net/github/stars/Th0rgal/opencode-ralph-wiggum)|Iterative AI development loops with self-correcting agents. Based on the Ralph Wiggum technique.|
+|[opencode-canvas](https://github.com/mailshieldai/opencode-canvas)|![GitHub Repo stars](https://badgen.net/github/stars/mailshieldai/opencode-canvas)|Interactive terminal canvases (calendars, documents, flight booking) in tmux splits. Port of claude-canvas for OpenCode.|
 ➡️ **[Suggest a new Plugin in our Discussions!](https://github.com/awesome-opencode/awesome-opencode/discussions/categories/plugins)**
 
 ## Themes


### PR DESCRIPTION
## Summary

Adds [opencode-canvas](https://github.com/mailshieldai/opencode-canvas) to the Plugins section.

**opencode-canvas** brings interactive terminal canvases to OpenCode, spawning rich TUI interfaces in tmux split panes. It's a port of [claude-canvas](https://github.com/dvdsgl/claude-canvas) adapted for the OpenCode ecosystem.

### Features

- **Calendar views** - Visual date pickers and meeting time selection
- **Document editors** - Rich markdown rendering with text selection
- **Flight booking** - Interactive flight search with seat maps
- **IPC communication** - Real-time bidirectional updates via Unix sockets

### Installation

```bash
npm install @mailshieldai/opencode-canvas
```

### npm package

https://www.npmjs.com/package/@mailshieldai/opencode-canvas