### PR TITLE
docs: add opencode-mystatus to plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,15 @@
 </details>
 
 <details>
+  <summary><b>opencode-mystatus</b> <img src="https://badgen.net/github/stars/vbgate/opencode-mystatus" height="14"/> - <i>Check AI subscription quotas</i></summary>
+  <blockquote>
+    Check all your AI subscription quotas in one command. Supports OpenAI (Plus/Pro/Codex, etc.), Zhipu AI, Google Antigravity, and more.
+    <br><br>
+    <a href="https://github.com/vbgate/opencode-mystatus">🔗 <b>View Repository</b></a>
+  </blockquote>
+</details>
+
+<details>
   <summary><b>Opencode Notify</b> <img src="https://badgen.net/github/stars/kdcokenny/opencode-notify" height="14"/> - <i>Native OS notifications</i></summary>
   <blockquote>
     Native OS notifications for OpenCode - know when tasks complete.


### PR DESCRIPTION
Added section for opencode-mystatus with details about AI subscription quotas.

## Submission Type

- [x] Plugin
- [ ] Project
- [ ] Theme
- [ ] Agent
- [ ] Resource

## Details

**Name:** opencode-mystatus
**Repository:** https://github.com/vbgate/opencode-mystatus
**Description:** Check all your AI subscription quotas in one command. Supports OpenAI (Plus/Pro/Codex, etc.), Zhipu AI, Google Antigravity, and more.

## Checklist

- [x] Relevant to OpenCode
- [x] Repository is public and accessible
- [x] Actively maintained
- [x] Not a duplicate
- [x] Entry added in alphabetical order

## Entry Format

Use this format in the appropriate README section:

```html
<details>
  <summary><b>Name</b> <img src="https://badgen.net/github/stars/owner/repo" height="14"/> - <i>Short description</i></summary>
  <blockquote>
    Full description.
    <br><br>
    <a href="https://github.com/owner/repo">🔗 <b>View Repository</b></a>
  </blockquote>
</details>
```

See [contributing.md](contributing.md) for full instructions.
