### PR TITLE
Add Open Agent to Projects section

### DIFF
--- a/README.md
+++ b/README.md
@@ -755,6 +755,15 @@
 </details>
 
 <details>
+  <summary><b>Open Agent</b> <img src="https://badgen.net/github/stars/Th0rgal/openagent" height="14"/> - <i>Self-hosted control plane</i></summary>
+  <blockquote>
+    Self-hosted control plane for OpenCode agents with isolated Linux workspaces (systemd-nspawn), git-backed Library configuration, and multi-platform dashboards (Next.js web, SwiftUI iOS).
+    <br><br>
+    <a href="https://github.com/Th0rgal/openagent">🔗 <b>View Repository</b></a>
+  </blockquote>
+</details>
+
+<details>
   <summary><b>OpenSpec</b> <img src="https://badgen.net/github/stars/Fission-AI/OpenSpec" height="14"/> - <i>Spec-driven development</i></summary>
   <blockquote>
     Spec-driven development with opencode - structured specification management.


### PR DESCRIPTION
## Description

Adding [Open Agent](https://github.com/Th0rgal/openagent) to the Projects section.

Open Agent is a self-hosted control plane for OpenCode agents featuring:
- Isolated Linux workspaces (systemd-nspawn containers)
- Git-backed Library configuration (skills, tools, rules, agents, MCPs)
- Multi-platform dashboards (Next.js web + SwiftUI iOS)
- Real-time mission monitoring and streaming
- MCP server registry

It complements OpenCode by handling orchestration, workspace isolation, and configuration management while delegating model inference to OpenCode.