### PR TITLE
Fix formatting issues in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,6 @@
   <summary><b>Envsitter Guard</b> <img src="https://badgen.net/github/stars/boxpositron/envsitter-guard" height="14"/> - <i>Prevent .env leaks</i></summary>
   <blockquote>
     OpenCode plugin that prevents agents/tools from reading or editing sensitive .env* files, while still allowing safe inspection via EnvSitter (keys + deterministic fingerprints; never values).
-
     <br><br>
     <a href="https://github.com/boxpositron/envsitter-guard">🔗 <b>View Repository</b></a>
   </blockquote>


### PR DESCRIPTION
removed a space in the README.md that prevented clicking the link for env guard plugin