### PR TITLE
docs: add Open Dispatch to projects

### DIFF
--- a/data/projects/open-dispatch.yaml
+++ b/data/projects/open-dispatch.yaml
@@ -1,0 +1,4 @@
+name: Open Dispatch
+repo: https://github.com/bobum/open-dispatch
+tagline: Control OpenCode from Slack or Microsoft Teams
+description: Bridge app connecting chat platforms (Slack/Teams) to AI coding assistants. Start sessions on desktop, guide them from your phone. Supports 75+ AI providers via OpenCode integration with session persistence and smart message routing.


### PR DESCRIPTION
## Summary

Adds **Open Dispatch** to the projects list.

**Open Dispatch** is a bridge app that connects chat platforms (Slack/Microsoft Teams) to AI coding assistants like OpenCode. It enables developers to:

- Start coding sessions on their desktop and guide them remotely from their phone
- Support 75+ AI providers via OpenCode integration
- Maintain session persistence and smart message routing across multiple projects

**Repository:** https://github.com/bobum/open-dispatch

## Checklist

- [x] Relevant - Directly related to OpenCode
- [x] Public - Repository is publicly accessible  
- [x] Maintained - Active commits within the last 6 months
- [x] Unique - Not a duplicate of existing entry
- [x] Complete - All required fields included (name, repo, tagline, description)