### PR TITLE
docs: add x402-tools-plugin to plugins

### DIFF
--- a/data/plugins/x402-tools-plugin.yaml
+++ b/data/plugins/x402-tools-plugin.yaml
@@ -1,4 +1,4 @@
 name: X402 Tools Plugin
-repo: https://github.com/itzannetos/x402-tools
+repo: https://github.com/TzannetosGiannis/x402-tools
 tagline: x402-powered OpenCode tools with automatic USDC micropayments.
 description: Adds x402-enabled tools to OpenCode and handles payments automatically on Base.


### PR DESCRIPTION
## Summary
- add X402 Tools Plugin entry to plugins list
- includes two tools: X search (real-time trends and discussions) and people research (profile/background lookup)
- plugin will expand with additional tools over time