### PR TITLE
feat: add opencode-plugin-openspec plugin

### DIFF
--- a/data/plugins/opencode-plugin-openspec.yaml
+++ b/data/plugins/opencode-plugin-openspec.yaml
@@ -1,0 +1,4 @@
+name: OpenSpec
+repo: https://github.com/Octane0411/opencode-plugin-openspec
+tagline: Architecture planning and specification agent
+description: An OpenCode plugin that integrates OpenSpec, providing a dedicated agent for planning and specifying software architecture.


### PR DESCRIPTION
Adds the OpenSpec plugin to the registry.

Plugin details:
- Name: OpenSpec
- Repo: https://github.com/Octane0411/opencode-plugin-openspec
- Description: An OpenCode plugin that integrates OpenSpec, providing a dedicated agent for planning and specifying software architecture.