### PR TITLE
docs: add opencode-plugin-openspec to plugins

### DIFF
--- a/data/plugins/opencode-plugin-openspec.yaml
+++ b/data/plugins/opencode-plugin-openspec.yaml
@@ -1,4 +1,4 @@
 name: OpenSpec
 repo: https://github.com/Octane0411/opencode-plugin-openspec
-tagline: Architecture planning and specification agent
+tagline: Add Architecture planning and specification agent for OpenSpec
 description: An OpenCode plugin that integrates OpenSpec, providing a dedicated agent for planning and specifying software architecture.


### PR DESCRIPTION
## Submission Type

- [x] Plugin
- [ ] Project
- [ ] Theme
- [ ] Agent
- [ ] Resource

## Details

**Name:** OpenSpec Plugin
**Repository:** https://github.com/Octane0411/opencode-plugin-openspec
**Tagline:** Add Architecture planning and specification agent for OpenSpec

## Checklist

- [x] Relevant to OpenCode
- [x] Repository is public and accessible
- [x] Actively maintained
- [x] Not a duplicate
- [x] YAML file in correct folder (`data/{category}/`)
- [x] Filename is kebab-case (e.g., `my-plugin.yaml`)