### PR TITLE
Add PAI-OpenCode - Daniel Miessler's PAI scaffolding for OpenCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -872,6 +872,15 @@
 </details>
 
 <details>
+  <summary><b>PAI-OpenCode</b> <img src="https://badgen.net/github/stars/Steffen025/pai-opencode" height="14"/> - <i>Daniel Miessler's PAI for OpenCode</i></summary>
+  <blockquote>
+    Complete port of Daniel Miessler's Personal AI Infrastructure (PAI) to OpenCode. Includes 33 skills, TELOS framework, multi-agent orchestration, memory system, and plugin-based lifecycle management. Works with any AI provider.
+    <br><br>
+    <a href="https://github.com/Steffen025/pai-opencode">🔗 <b>View Repository</b></a>
+  </blockquote>
+</details>
+
+<details>
   <summary><b>Qwen Code OAI Proxy</b> <img src="https://badgen.net/github/stars/aptdnfapt/qwen-code-oai-proxy" height="14"/> - <i>Qwen model proxy</i></summary>
   <blockquote>
     An OpenAI-Compatible Proxy Server for Qwen models.


### PR DESCRIPTION
## Summary

Adds **PAI-OpenCode** to the PROJECTS section.

**PAI-OpenCode** is the complete port of [Daniel Miessler's Personal AI Infrastructure (PAI)](https://github.com/danielmiessler/Personal_AI_Infrastructure) to OpenCode.

### Features

- 33 skills fully ported (CORE, Art, Browser, Security, Research, Fabric...)
- TELOS framework for deep personalization
- Multi-agent orchestration
- Memory and learning system
- Plugin-based lifecycle management
- 8 AI providers out of the box (Anthropic, OpenAI, Google, Groq, AWS Bedrock, Azure, ZEN free, Ollama)
- Interactive setup wizard (~2 min installation)

### Links

- **Repository:** https://github.com/Steffen025/pai-opencode
- **Release:** https://github.com/Steffen025/pai-opencode/releases/tag/v1.0.0
- **Original PAI:** https://github.com/danielmiessler/Personal_AI_Infrastructure