### PR TITLE
docs: add autotitle to plugins

### DIFF
--- a/data/plugins/autotitle.yaml
+++ b/data/plugins/autotitle.yaml
@@ -1,0 +1,4 @@
+name: Autotitle
+repo: https://github.com/pawelma/opencode-autotitle
+tagline: AI-powered automatic session naming
+description: Two-phase session titling - instant keyword titles on user message, refined AI titles after response. Auto-selects cheapest model (flash/haiku/fast), respects custom titles, zero configuration needed.


### PR DESCRIPTION
## Summary

Adds opencode-autotitle plugin to the plugins list.

**Plugin:** [opencode-autotitle](https://github.com/pawelma/opencode-autotitle)

AI-powered automatic session naming with two-phase titling:
- Instant keyword-based title on user message
- Refined AI title after response using cheapest available model

## Checklist

- [x] Relevant - Directly related to OpenCode
- [x] Public - Repository is publicly accessible
- [x] Maintained - Active commits within the last 6 months
- [x] Unique - Not a duplicate of existing entry
- [x] Complete - All required fields included