### PR TITLE
Add PPTX from Layouts plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,15 @@
 </details>
 
 <details>
+  <summary><b>PPTX from Layouts</b> <img src="https://badgen.net/github/stars/tristan-mcinnis/pptx-from-layouts-skill" height="14"/> - <i>PowerPoint from slide master layouts</i></summary>
+  <blockquote>
+    Generate consultant-quality PowerPoint presentations from markdown outlines using your template's actual slide master layouts, not text overlays. Includes template profiling, visual types, and surgical edit mode.
+    <br><br>
+    <a href="https://github.com/tristan-mcinnis/pptx-from-layouts-skill">🔗 <b>View Repository</b></a>
+  </blockquote>
+</details>
+
+<details>
   <summary><b>Ralph Wiggum</b> <img src="https://badgen.net/github/stars/Th0rgal/opencode-ralph-wiggum" height="14"/> - <i>Self-correcting agent loops</i></summary>
   <blockquote>
     Iterative AI development loops with self-correcting agents based on the Ralph Wiggum technique.


### PR DESCRIPTION
## Summary

Adds **pptx-from-layouts-skill** to the Plugins section - a PowerPoint generation plugin that uses slide master layouts properly instead of text overlays.

## What it does

Most PowerPoint generation approaches overlay text on template slides, fighting with backgrounds and decorative elements. This plugin properly uses slide master layouts, placing content in actual placeholders to preserve professional design.

## Features

- **Markdown → PPTX generation** - Write outlines, get consultant-quality decks
- **Template profiling** - Works with any well-designed corporate template
- **Visual types** - Semantic layout selection (hero, process, comparison, cards, tables)
- **Edit mode** - Surgical changes to existing decks
- **Validation** - Built-in quality checks

## Repository

https://github.com/tristan-mcinnis/pptx-from-layouts-skill

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)