### PR TITLE
docs: add opencode-personality to plugins

### DIFF
--- a/data/plugins/opencode-personality.yaml
+++ b/data/plugins/opencode-personality.yaml
@@ -1,0 +1,4 @@
+name: opencode-personality
+repo: https://github.com/joostvanwollingen/opencode-personality
+tagline: A configurable personality and mood system plugin for OpenCode.
+description: Give your AI assistant a distinct personality with customizable moods that drift over time.


### PR DESCRIPTION
## Submission Type

- [X] Plugin
- [ ] Project
- [ ] Theme
- [ ] Agent
- [ ] Resource

## Details

**Name:**  opencode-personality
**Repository:** https://github.com/joostvanwollingen/opencode-personality
**Tagline:** A configurable personality and mood system plugin for [OpenCode](https://opencode.ai). Give your AI assistant a distinct personality with customizable moods that drift over time.

## Checklist

- [X] Relevant to OpenCode
- [X] Repository is public and accessible
- [X] Actively maintained
- [X] Not a duplicate
- [X] YAML file in correct folder (`data/{category}/`)
- [X] Filename is kebab-case (e.g., `my-plugin.yaml`)