### PR TITLE
docs: add system-prompt-logger to plugins

### DIFF
--- a/data/plugins/opencode-system-prompt-logger.yaml
+++ b/data/plugins/opencode-system-prompt-logger.yaml
@@ -1,0 +1,4 @@
+name: System Prompt Logger
+repo: https://github.com/tlinhart/opencode-system-prompt-logger
+tagline: System prompt logger
+description: OpenCode plugin that intercepts the system prompt before it's sent to the LLM and logs it.


### PR DESCRIPTION
## Submission Type

- [X] Plugin
- [ ] Project
- [ ] Theme
- [ ] Agent
- [ ] Resource

## Details

**Name:** System Prompt Logger
**Repository:** https://github.com/tlinhart/opencode-system-prompt-logger
**Tagline:** System prompt logger

## Checklist

- [X] Relevant to OpenCode
- [X] Repository is public and accessible
- [X] Actively maintained
- [X] Not a duplicate
- [X] YAML file in correct folder (`data/{category}/`)
- [X] Filename is kebab-case (e.g., `my-plugin.yaml`)