### PR TITLE
docs: add puter-auth to plugins

### DIFF
--- a/data/plugins/puter-auth.yaml
+++ b/data/plugins/puter-auth.yaml
@@ -1,0 +1,4 @@
+name: Puter Auth
+repo: https://github.com/Mihai-Codes/opencode-puter-auth
+tagline: 500+ AI models via Puter.com OAuth
+description: Access Claude Opus 4.5, GPT-5, Gemini, DeepSeek, and 400+ free OpenRouter models through Puter.com authentication. Features automatic model fallback, multi-account rotation, and MCP server mode.


### PR DESCRIPTION
## Summary

Adds **opencode-puter-auth** plugin to the awesome-opencode plugins list.

## Plugin Details

- **Name:** Puter Auth
- **Repository:** https://github.com/Mihai-Codes/opencode-puter-auth
- **npm:** `opencode-puter-auth`

## Features

- Access 500+ AI models (Claude Opus 4.5, GPT-5, Gemini, DeepSeek) via Puter.com OAuth
- 400+ FREE OpenRouter models with `:free` suffix
- Automatic model fallback on rate limits
- Multi-account rotation support
- MCP server mode for Zed IDE and Claude Desktop
- AI SDK provider for standalone usage
- Real-time SSE streaming, tool calling, and vision support

## Checklist

- [x] Relevant - Directly related to OpenCode (authentication plugin)
- [x] Public - Repository is publicly accessible
- [x] Maintained - Active commits within the last 6 months (last commit: 2 days ago)
- [x] Unique - No existing Puter.com integration in the list
- [x] Complete - All required fields included (name, repo, tagline, description)