### PR TITLE
docs: add opencode-token-monitor plugin

### DIFF
--- a/data/plugins/token-monitor.yaml
+++ b/data/plugins/token-monitor.yaml
@@ -1,0 +1,4 @@
+name: Token Monitor
+repo: https://github.com/Ainsley0917/opencode-token-monitor
+tagline: Token analysis & cost tracking with budgets, trends, and per-project analytics
+description: Track token usage (input/output/reasoning/cache), estimate costs, view daily trends with ASCII charts, set budget alerts, and export data. Supports per-agent breakdown, agent×model cross-analysis, and project-scoped analytics.


### PR DESCRIPTION
## Summary

Adding [opencode-token-monitor](https://github.com/Ainsley0917/opencode-token-monitor) to the plugins list.

**What it does:**
- Token usage tracking (input/output/reasoning/cache) with cost estimation
- Daily cost trends with ASCII bar charts
- Budget alerts (daily/weekly/monthly thresholds)
- Per-agent and agent×model cross-breakdown
- Project-scoped analytics
- Export to JSON/CSV/Markdown

**npm:** [`opencode-token-monitor`](https://www.npmjs.com/package/opencode-token-monitor)

**Install:**
```json
{ "plugin": ["opencode-token-monitor@latest"] }
```