### PR TITLE
docs: add opencode-mission-control to plugins

### DIFF
--- a/data/plugins/opencode-mission-control.yaml
+++ b/data/plugins/opencode-mission-control.yaml
@@ -1,0 +1,4 @@
+name: OpenCode Mission Control
+repo: https://github.com/nigel-dev/opencode-mission-control
+tagline: Command center for parallel agents — worktree isolation, DAG plans, merge train, PRs
+description: Orchestrates parallel OpenCode agents in tmux-isolated git worktrees with live inspection (capture/attach/diff), a dashboard overview, agent status reporting, and in-chat notifications. Supports DAG-based plans with autopilot/copilot/supervisor modes and a merge train with test gating and automatic rollback.


### PR DESCRIPTION
Adds **OpenCode Mission Control** — a command-center plugin for running parallel agents in tmux-isolated git worktrees.

**Key features:**
- One worktree + tmux session per job (no file conflicts)
- Live inspection: `mc_capture`, `mc_attach`, `mc_diff`
- Dashboard overview + in-chat notifications + agent reporting pipeline
- DAG plans with `dependsOn` + merge train (test gate + rollback)
- Plan modes: autopilot / copilot / supervisor

- **npm:** https://www.npmjs.com/package/opencode-mission-control
- **GitHub:** https://github.com/nigel-dev/opencode-mission-control