### PR TITLE
Add Everything Claude Code (ECC Universal) plugin

### DIFF
--- a/data/plugins/everything-claude-code.yaml
+++ b/data/plugins/everything-claude-code.yaml
@@ -1,0 +1,9 @@
+name: Everything Claude Code (ECC Universal)
+repo: https://github.com/affaan-m/everything-claude-code
+tagline: "Battle-tested agents, skills, hooks, and rules for 6 languages"
+description: >
+  Complete collection of Claude Code configurations evolved over 10+ months
+  of daily use. 14 agents, 28 skills, 30 commands, rules for TypeScript,
+  Python, Go, Java, Django, and Spring Boot. Now universal — works with
+  Claude Code, OpenCode, and Cursor. Install via npm: ecc-universal.
+  42K+ GitHub stars. Built by an Anthropic hackathon winner.


### PR DESCRIPTION
## Summary

Adds [Everything Claude Code (ECC Universal)](https://github.com/affaan-m/everything-claude-code) to the plugins directory.

**What is ECC?**
A complete collection of battle-tested configurations for AI coding agents, evolved over 10+ months of intensive daily use. Originally built for Claude Code, now universal — works with Claude Code, OpenCode, and Cursor.

**Key stats:**
- 42K+ GitHub stars
- 14 specialized agents (architect, code-reviewer, security-reviewer, tdd-guide, e2e-runner, etc.)
- 28 skills across 6 languages (TypeScript, Python, Go, Java, Django, Spring Boot)
- 30 slash commands for multi-agent orchestration
- Production-ready hooks for auto-formatting, type-checking, and security auditing
- npm package: `ecc-universal`

**OpenCode support:**
- Full `.opencode/` directory with plugin manifest, commands, tools, and instructions
- 12 agents mapped to OpenCode's agent system
- 24 commands mapped to OpenCode's command system
- Hook event mapping (PreToolUse → tool.execute.before, etc.)
- Install via `npm install ecc-universal`

## Checklist

- [x] Entry is relevant to OpenCode
- [x] Repository is public
- [x] Actively maintained (daily commits)
- [x] Not duplicating existing entries
- [x] All required YAML fields filled
- [x] File uses kebab-case naming
- [x] Placed in `data/plugins/` directory