### PR TITLE
docs: add openkilo to plugins

### DIFF
--- a/data/plugins/openkilo.yaml
+++ b/data/plugins/openkilo.yaml
@@ -1,0 +1,7 @@
+name: OpenKilo
+repo: https://github.com/AnganSamadder/openkilo
+tagline: Access frontier open-source AI models for free with zero config
+description: >-
+  Provides instant access to frontier OSS AI models (GLM 5, Kimi K2.5, DeepSeek v3.2, 
+  Llama, Qwen, and more) through Kilo's OpenRouter-compatible gateway. No API key 
+  required for free models. Optional OAuth/API key for 350+ paid models.


### PR DESCRIPTION
Adds OpenKilo to the plugins list.

## Plugin Details
- **Name**: OpenKilo
- **Repository**: https://github.com/AnganSamadder/openkilo
- **Description**: Access frontier open-source AI models for free through Kilo Gateway with zero config

## Features
- 40+ free AI models (GLM 5, Kimi K2.5, DeepSeek v3.2, Llama, Qwen, etc.)
- No API key required for free models
- OpenRouter-compatible gateway
- Optional OAuth/API key for 350+ paid models

## Checklist
- [x] Public repository
- [x] Active development
- [x] Unique plugin
- [x] Directly related to OpenCode