### PR TITLE
docs: add opencode-plan-manager to plugins

### DIFF
--- a/data/plugins/opencode-plan-manager.yaml
+++ b/data/plugins/opencode-plan-manager.yaml
@@ -1,0 +1,4 @@
+name: OpenCode Plan Manager
+repo: https://github.com/yurihbm/opencode-plan-manager
+tagline: AI-Native Implementation Planning for Modern Agentic Workflows
+description: High-performance, minimalist plugin designed to bridge the gap between complex implementation strategies and autonomous execution. Selective context loading, zero-hallucination schemas, visible filesystem kanban.


### PR DESCRIPTION
## Submission Type

- [x] Plugin
- [ ] Project
- [ ] Theme
- [ ] Agent
- [ ] Resource

## Details

**Name:** OpenCode Plan Manager
**Repository:** https://github.com/yurihbm/opencode-plan-manager
**Tagline:** AI-Native Implementation Planning for Modern Agentic Workflows

## Checklist

- [x] Relevant to OpenCode
- [x] Repository is public and accessible
- [x] Actively maintained
- [x] Not a duplicate
- [x] YAML file in correct folder (`data/{category}/`)
- [x] Filename is kebab-case (e.g., `my-plugin.yaml`)
