### PR TITLE
docs: add oc-mnemoria to plugins

### DIFF
--- a/data/plugins/oc-mnemoria.yaml
+++ b/data/plugins/oc-mnemoria.yaml
@@ -1,0 +1,4 @@
+name: oc-mnemoria
+repo: https://github.com/one-bit/oc-mnemoria
+tagline: Persistent shared memory (hive mind) for OpenCode agents across sessions
+description: Gives all OpenCode agents a shared persistent memory store where every agent can read and write. Each entry is tagged with the creating agent (plan, build, ask, review) so no context is lost between roles. Powered by the mnemoria Rust engine with hybrid BM25 + semantic search, CRC32 checksum chains, and an append-only binary format. Includes 7 tools and /mn-* slash commands.


### PR DESCRIPTION
## Summary

Adds **oc-mnemoria** — persistent shared memory (hive mind) for OpenCode agents.

## What is oc-mnemoria?

Every new OpenCode session starts from zero context. oc-mnemoria gives all your agents a shared persistent memory that survives across sessions — a "hive mind" where every agent can read and write.

### Highlights

- **Shared hive mind** — All agents (plan, build, ask, review) share one memory store. The build agent sees what the plan agent decided; the review agent recalls bugs the build agent fixed. No context is lost between roles.
- **Per-agent tagging** — Every entry is tagged with the agent that created it. Search or browse memories filtered by agent, or view the full shared timeline.
- **Selective forgetting** — Agents can mark outdated memories as forgotten and compact the store, keeping memory accurate as the project evolves.
- **Git-friendly single file** — The entire memory is one append-only binary file. Commit it alongside your code to version-control your agent's memory, or `.gitignore` it.
- **Blazing fast Rust engine** — Powered by [mnemoria](https://github.com/one-bit/mnemoria): sub-millisecond hybrid search (BM25 full-text + semantic similarity via Reciprocal Rank Fusion), ~9,900 writes/sec, CRC32 checksum chains with crash recovery.
- **Automatic context injection** — Relevant memories and past intents are injected into the system prompt at session start.
- **100% local** — No cloud, no API calls. Everything on your filesystem.

### Included

- 7 tools: `remember`, `search_memory`, `ask_memory`, `memory_stats`, `timeline`, `forget`, `compact`
- 6 slash commands: `/mn-ask`, `/mn-search`, `/mn-stats`, `/mn-recent`, `/mn-timeline`, `/mn-forget`, `/mn-compact`
- Full CLI via the `mnemoria` binary

### Links

- npm: https://www.npmjs.com/package/oc-mnemoria
- GitHub: https://github.com/one-bit/oc-mnemoria
- Rust engine: https://crates.io/crates/mnemoria
- MIT licensed, actively maintained