### PR TITLE
docs: add P4OC to projects

### DIFF
--- a/data/projects/p4oc.yaml
+++ b/data/projects/p4oc.yaml
@@ -1,0 +1,4 @@
+name: P4OC (Pocket for OpenCode)
+repo: https://github.com/theblazehen/P4OC
+tagline: Android client for OpenCode
+description: Native Android app for controlling OpenCode from your phone. Chat with AI, manage sessions, browse files with syntax highlighting, view diffs, and use an embedded terminal — all styled with a terminal UI aesthetic. Available on Google Play.


### PR DESCRIPTION
Adds [P4OC (Pocket for OpenCode)](https://github.com/theblazehen/P4OC) to the Projects section.

Native Android client for OpenCode. Connect to a running OpenCode server and control it from your phone — chat, manage sessions, browse files, view diffs, embedded terminal.

- [Google Play](https://play.google.com/store/apps/details?id=dev.blazelight.p4oc)
- Open source (GitHub releases with optimized APK)
- Built with Kotlin + Jetpack Compose
- Terminal UI aesthetic, not stock Material3