### PR TITLE
Add Oh My Kiro plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,15 @@
 </details>
 
 <details>
+  <summary><b>Oh My Kiro</b> <img src="https://badgen.net/github/stars/1nhann/oh-my-kiro" height="14"/> - <i>AWS Kiro-inspired multi-agent SDD coding agent harness</i></summary>
+  <blockquote>
+    A spec-driven, multi-agent coding plugin for OpenCode inspired by AWS Kiro. Features requirements-first workflow, spec task execution, context gathering, background tasks, and multimodal support.
+    <br><br>
+    <a href="https://github.com/1nhann/oh-my-kiro">🔗 <b>View Repository</b></a>
+  </blockquote>
+</details>
+
+<details>
   <summary><b>Oh My Opencode</b> <img src="https://badgen.net/github/stars/code-yeongyu/oh-my-opencode" height="14"/> - <i>Agents & Pre-built tools</i></summary>
   <blockquote>
     Background agents, pre-built tools (LSP/AST/MCP), curated agents, and a Claude Code compatible layer.

--- a/data/plugins/oh-my-kiro.yaml
+++ b/data/plugins/oh-my-kiro.yaml
@@ -1,0 +1,4 @@
+name: Oh My Kiro
+repo: https://github.com/1nhann/oh-my-kiro
+tagline: AWS Kiro-inspired multi-agent SDD coding agent harness
+description: A spec-driven, multi-agent coding plugin for OpenCode inspired by AWS Kiro. Features requirements-first workflow, spec task execution, context gathering, background tasks, and multimodal support.


### PR DESCRIPTION
## Submission Type

- [x] Plugin
- [ ] Project
- [ ] Theme
- [ ] Agent
- [ ] Resource

## Details

**Name:** Oh My Kiro
**Repository:** https://github.com/1nhann/oh-my-kiro
**Tagline:** AWS Kiro-inspired multi-agent SDD coding agent harness

## Checklist

- [x] Relevant to OpenCode
- [x] Repository is public and accessible
- [x] Actively maintained
- [x] Not a duplicate
- [x] YAML file in correct folder (`data/plugins/`)
- [x] Filename is kebab-case (e.g., `oh-my-kiro.yaml`)

## YAML Format

Create a file in `data/plugins/oh-my-kiro.yaml`:

```yaml
name: Oh My Kiro
repo: https://github.com/1nhann/oh-my-kiro
tagline: AWS Kiro-inspired multi-agent SDD coding agent harness
description: A spec-driven, multi-agent coding plugin for OpenCode inspired by AWS Kiro. Features requirements-first workflow, spec task execution, context gathering, background tasks, and multimodal support.
```

