### PR TITLE
docs: add OpenGUI to projects

### DIFF
--- a/data/projects/opengui.yaml
+++ b/data/projects/opengui.yaml
@@ -1,0 +1,13 @@
+name: OpenGUI
+repo: https://github.com/akemmanuel/OpenGUI
+tagline: Native desktop GUI for OpenCode with streaming, prompt queues, and multi-project support.
+description: >
+  OpenGUI is an open-source Electron desktop application that provides a rich graphical interface
+  for OpenCode. It connects to multiple project directories simultaneously, letting you manage
+  separate AI sessions per project. Responses stream in real-time via SSE with live token and
+  context usage tracking. A built-in prompt queue lets you stack messages while the assistant is
+  busy, automatically dispatching them when idle. Switch between AI providers, models, agents,
+  and model variants on the fly, use slash commands, manage MCP servers and skills, and optionally
+  dictate prompts via speech-to-text. Code blocks are syntax-highlighted with Shiki, math
+  expressions render via KaTeX, and the UI supports both dark and light themes. Builds as .deb
+  for Linux and .dmg for macOS.


### PR DESCRIPTION
## Summary

- Adds **OpenGUI** to the projects list — a native Electron desktop GUI for OpenCode.

## Entry Details

- **Name:** OpenGUI
- **Repo:** https://github.com/akemmanuel/OpenGUI
- **Category:** `data/projects/`
- **Tagline:** Native desktop GUI for OpenCode with streaming, prompt queues, and multi-project support.

## What is OpenGUI?

OpenGUI is an open-source Electron desktop application that provides a rich graphical interface for OpenCode. Key features include:

- Multi-project session management (separate AI sessions per directory)
- Real-time SSE streaming with live token/context tracking
- Built-in prompt queue (stack messages while the assistant is busy)
- Switch between AI providers, models, agents, and variants on the fly
- Slash commands, MCP server management, and skills support
- Speech-to-text prompt input
- Shiki syntax highlighting and KaTeX math rendering
- Dark and light themes
- Builds as `.deb` (Linux) and `.dmg` (macOS)

## Checklist

- [x] Relevant — Desktop GUI for OpenCode
- [x] Public — Repository is publicly accessible
- [x] Maintained — Active commits
- [x] Unique — No existing OpenGUI entry
- [x] Complete — All required YAML fields included