### PR TITLE
docs: add opencode-remote-agent to plugins

### DIFF
--- a/data/plugins/remote-agent.yaml
+++ b/data/plugins/remote-agent.yaml
@@ -1,0 +1,4 @@
+name: Remote Agent
+repo: https://github.com/petrjirous/opencode-remote-agent
+tagline: Offload long-running tasks to AWS ECS Fargate
+description: Launch OpenCode agent tasks on remote AWS ECS Fargate containers. Automatically uploads your workspace and session context so the remote agent can continue where you left off. Apply changes back locally via git patch.


### PR DESCRIPTION
## Summary

- Adds **opencode-remote-agent** to the plugins list
- An OpenCode plugin that launches agent tasks on remote AWS ECS Fargate containers, uploads workspace + session context, and lets you apply changes back locally via git patch
- npm: [opencode-remote-agent](https://www.npmjs.com/package/opencode-remote-agent)
- Repo: https://github.com/petrjirous/opencode-remote-agent