### PR TITLE
docs: add python-agent to agents

### DIFF
--- a/data/agents/python-agent.yaml
+++ b/data/agents/python-agent.yaml
@@ -1,0 +1,19 @@
+name: Python Expert Agent for OpenCode
+repo: https://github.com/amrahman90/python-expert-agent
+tagline: Python Expert Agent tool for OpenCode - 4 subagents, 10 skills
+description: A custom agent configuration for Python projects.
+  Includes
+  - 1 Primary Custom Agent `python-expert` with intelligent skill loading
+  - Predefined 4 Specialized Subagents for Code generation, review, testing, and exploration
+  - 10 On-Demand Skills for FastAPI, SQLAlchemy, pytest, asyncio, and more
+  - 3 Context Files for Standards, patterns, and security guidelines
+
+scope:
+  - project  # .opencode/agent/
+
+tags:
+  - python
+  - agent
+  - skill
+
+min_version: "0.0.4"

--- a/data/agents/python-agent.yaml
+++ b/data/agents/python-agent.yaml
@@ -4,9 +4,9 @@ tagline: Python Expert Agent tool for OpenCode - 4 subagents, 10 skills
 description: A custom agent configuration for Python projects.
   Includes
   - 1 Primary Custom Agent `python-expert` with intelligent skill loading
-  - Predefined 4 Specialized Subagents for Code generation, review, testing, and exploration
-  - 10 On-Demand Skills for FastAPI, SQLAlchemy, pytest, asyncio, and more
-  - 3 Context Files for Standards, patterns, and security guidelines
+  - Predefined Specialized Subagents for Code generation, review, testing, and exploration
+  - On-Demand Skills for FastAPI, SQLAlchemy, pytest, asyncio, and more
+  - Context Files for Standards, patterns, and security guidelines
 
 scope:
   - project  # .opencode/agent/

--- a/data/agents/python-agent.yaml
+++ b/data/agents/python-agent.yaml
@@ -1,19 +1,4 @@
 name: Python Expert Agent for OpenCode
 repo: https://github.com/amrahman90/python-expert-agent
-tagline: Python Expert Agent tool for OpenCode - 4 subagents, 10 skills
-description: A custom agent configuration for Python projects.
-  Includes
-  - 1 Primary Custom Agent `python-expert` with intelligent skill loading
-  - Predefined Specialized Subagents for Code generation, review, testing, and exploration
-  - On-Demand Skills for FastAPI, SQLAlchemy, pytest, asyncio, and more
-  - Context Files for Standards, patterns, and security guidelines
-
-scope:
-  - project  # .opencode/agent/
-
-tags:
-  - python
-  - agent
-  - skill
-
-min_version: "0.0.4"
+tagline: Python Expert Agent toolkit for OpenCode with subagents and skills
+description: A custom configurable agent toolkit includes 1 Primary Custom Agent python-expert with intelligent skill loading, Predefined Specialized Subagents for Code generation, review, testing, and exploration, On-Demand Skills for Python development projects, Context Files for Standards, patterns, and security guidelines.


### PR DESCRIPTION
## Submission Type

- [ ] Plugin
- [ ] Project
- [ ] Theme
- [x] Agent
- [ ] Resource

## Details

**Name:** Python Expert Agent for OpenCode
**Repository:** https://github.com/amrahman90/python-expert-agent
**Tagline:** Python Expert Agent tool for OpenCode - 4 subagents, 10 skills

## Checklist

- [x] Relevant to OpenCode
- [x] Repository is public and accessible
- [x] Actively maintained
- [x] Not a duplicate
- [x] YAML file in correct folder (`data/agents/`)
- [x] Filename is kebab-case (e.g., `python-agent.yaml`)

## YAML Format

Create a file in `data\agents\python-agent.yaml`:

```yaml
name: Python Expert Agent for OpenCode
repo: https://github.com/amrahman90/python-expert-agent
tagline: Python Expert Agent tool for OpenCode - 4 subagents, 10 skills
description: A custom agent configuration for Python projects.
  Includes
  - 1 Primary Custom Agent `python-expert` with intelligent skill loading
  - Predefined 4 Specialized Subagents for Code generation, review, testing, and exploration
  - 10 On-Demand Skills for FastAPI, SQLAlchemy, pytest, asyncio, and more
  - 3 Context Files for Standards, patterns, and security guidelines
```
