### PR TITLE
Add OpenPaw — personal assistant skills for Claude Code

### DIFF
--- a/data/projects/openpaw.yaml
+++ b/data/projects/openpaw.yaml
@@ -1,0 +1,5 @@
+name: OpenPaw
+repo: https://github.com/daxaur/openpaw
+tagline: Personal assistant with 38 skills via CLI
+description: Open-source CLI tool (npx pawmode) that turns Claude Code into a personal assistant with 38 skills — email, calendar, Spotify, smart home, Slack, GitHub, and more. No daemon, no cloud, MIT licensed.
+homepage: https://www.npmjs.com/package/pawmode


### PR DESCRIPTION
Hey! Wanted to add [OpenPaw](https://github.com/daxaur/openpaw) to the projects list.

It's an open-source CLI tool (`npx pawmode`) that turns Claude Code into a personal assistant with 38 skills — things like email, calendar, Spotify, smart home, Slack, GitHub, and more. No daemon or cloud service needed, just skills that run locally. MIT licensed.

- **Repo:** https://github.com/daxaur/openpaw
- **npm:** https://www.npmjs.com/package/pawmode

Let me know if anything needs updating. Thanks for maintaining this list!