### PR TITLE
docs: add open-plan-annotator to plugins

### DIFF
--- a/data/plugins/open-plan-annotator.yaml
+++ b/data/plugins/open-plan-annotator.yaml
@@ -1,5 +1,5 @@
 name: open-plan-annotator
 repo: https://github.com/ndom91/open-plan-annotator
 tagline: Annotate LLM plans like a Google Doc!
-description: A fully local agentic coding plugin that intercepts plan mode and opens an annotation UI in your browser. Mark up the plan, send structured feedback to the agent, and receive a revised version — iterate as many times as you need until you're ready to approve. Select text to strikethrough, replace, insert, or comment — then approve the plan or request changes
+description: A fully local agentic coding plugin that intercepts plan mode and opens an annotation UI in your browser. Select text to strikethrough, replace, insert, or comment — then approve the plan or request changes
 


### PR DESCRIPTION
## Submission Type

- [x] Plugin
- [ ] Project
- [ ] Theme
- [ ] Agent
- [ ] Resource

## Details

**Name:** open-plan-annotator
**Repository:** https://github.com/ndom91/open-plan-annotator
**Tagline:** Annotate LLM plans like a Google Doc!

## Checklist

- [x] Relevant to OpenCode
- [x] Repository is public and accessible
- [x] Actively maintained
- [x] Not a duplicate
- [x] YAML file in correct folder (`data/{category}/`)
- [x] Filename is kebab-case (e.g., `my-plugin.yaml`)

## YAML Format

Create a file in `data/{category}/your-entry.yaml`:

```yaml
name: Your Entry Name
repo: https://github.com/owner/repo
tagline: Short punchy summary (shown in collapsed view)
description: Longer description explaining what it does.
```

See [contributing.md](contributing.md) for full instructions.
