### PR TITLE
docs: add Vibe Coding Slack Notifier plugin

### DIFF
--- a/data/plugins/vibe-coding-slack-notifier.yaml
+++ b/data/plugins/vibe-coding-slack-notifier.yaml
@@ -1,0 +1,4 @@
+name: Vibe Coding Slack Notifier
+repo: https://github.com/Wangmerlyn/vibe-coding-slack-notifier
+tagline: Slack DM alerts for OpenCode task completion
+description: OpenCode-compatible Slack notifier plugin and toolkit for Codex, OpenCode, Claude Code, and Gemini workflows.


### PR DESCRIPTION
## Summary
- add Vibe Coding Slack Notifier to data/plugins
- include required fields (name, repo, tagline, description) following contribution format

## Validation
- ran npm run validate
- new file passed schema checks

## Entry added
- data/plugins/vibe-coding-slack-notifier.yaml
