### PR TITLE
docs: add opencode-dotenv to plugins

### DIFF
--- a/data/plugins/opencode-dotenv.yaml
+++ b/data/plugins/opencode-dotenv.yaml
@@ -1,0 +1,4 @@
+name: opencode-dotenv
+repo: https://github.com/tianhuil/opencode-dotenv
+tagline: "The missing dotenv bridge for AI-powered coding: multi-environment, encrypted, templated, zero friction."
+description: Automatically loads .env files before AI-triggered bash commands. Supports multi-environment configs (.env.development, .env.production), encrypted secrets with dotenvx, variable expansion, and safe merging without overriding existing environment variables.


### PR DESCRIPTION
## Submission Type

- [X] Plugin

## Details

**Name:** opencode-dotenv
**Repository:** https://github.com/tianhuil/opencode-dotenv
**Tagline:** The missing dotenv bridge for AI-powered coding: multi-environment, encrypted, templated, zero friction.
**Description:** Automatically loads .env files before AI-triggered bash commands. Supports multi-environment configs (.env.development, .env.production), encrypted secrets with dotenvx, variable expansion, and safe merging without overriding existing environment variables.

## Checklist

- [x] Relevant to OpenCode
- [x] Repository is public and accessible
- [x] Actively maintained
- [x] Not a duplicate
- [x ] YAML file in correct folder (`data/{category}/`)
- [x] Filename is kebab-case (e.g., `my-plugin.yaml`)

## YAML Format

Create a file in `data/{category}/your-entry.yaml`:

```yaml
name: Your Entry Name
repo: https://github.com/owner/repo
tagline: Short punchy summary (shown in collapsed view)
description: Longer description explaining what it does.
```

See [contributing.md](contributing.md) for full instructions.

@ShamanicArts 
