### PR TITLE
feat: add AgentField, SWE-AF, and SEC-AF

### DIFF
--- a/data/agents/sec-af.yaml
+++ b/data/agents/sec-af.yaml
@@ -1,0 +1,7 @@
+name: SEC-AF
+repo: https://github.com/Agent-Field/sec-af
+tagline: Multi-agent security auditor — orchestrates a 250+ agent swarm that proves exploitability, SARIF for CI
+description: >
+  Multi-agent security auditor. Orchestrates a 250+ agent swarm to find
+  vulnerabilities and prove they're exploitable — not just flag patterns.
+  SARIF output for GitHub Actions integration. Apache 2.0.

--- a/data/agents/swe-af.yaml
+++ b/data/agents/swe-af.yaml
@@ -1,0 +1,6 @@
+name: SWE-AF
+repo: https://github.com/Agent-Field/SWE-AF
+tagline: Autonomous software engineering agent team — orchestrates a 400+ agent swarm for planning, coding, testing, and review
+description: >
+  Autonomous software engineering agent team. Orchestrates a 400+ agent swarm
+  across the full development lifecycle from a single API call. Apache 2.0.

--- a/data/projects/agentfield.yaml
+++ b/data/projects/agentfield.yaml
@@ -1,0 +1,7 @@
+name: AgentField
+repo: https://github.com/Agent-Field/agentfield
+tagline: Control plane for orchestrating AI agent swarms as microservices — best-in-class DX
+description: >
+  Open-source infrastructure for orchestrating AI agent swarms at scale.
+  Best-in-class developer experience with SDKs for Python, Go, and TypeScript.
+  Handles async execution, durable state, and observability.


### PR DESCRIPTION
## Summary

Adds three entries to awesome-opencode:

- **AgentField** (`data/projects/agentfield.yaml`) — Open-source control plane
  for orchestrating AI agent swarms as microservices. SDKs for Python, Go,
  and TypeScript.

- **SWE-AF** (`data/agents/swe-af.yaml`) — Autonomous software engineering
  agent team. 400+ agent swarm for planning, coding, testing, and review.

- **SEC-AF** (`data/agents/sec-af.yaml`) — Multi-agent security auditor.
  250+ agent swarm for vulnerability discovery. SARIF output for CI.

All Apache 2.0, actively maintained.