### PR TITLE
Add marcodiniz/ag-local-bridge to Projects

### DIFF
--- a/data/projects/ag-local-bridge.yaml
+++ b/data/projects/ag-local-bridge.yaml
@@ -1,0 +1,4 @@
+name: Antigravity Local Bridge
+repo: https://github.com/marcodiniz/ag-local-bridge
+tagline: Local OpenAI-compatible API bridge for Antigravity
+description: An Antigravity extension that exposes a local OpenAI-compatible HTTP server on localhost:11435. Enables any OpenAI-compatible tool (OpenCode, Aider, Cline, Continue.dev) to use Antigravity's Gemini, Claude, and GPT models without additional API keys.


### PR DESCRIPTION
Adds [ag-local-bridge](https://github.com/marcodiniz/ag-local-bridge) to the **Projects** section.

## Description

`ag-local-bridge` is an Antigravity extension that exposes a local OpenAI-compatible HTTP API on `localhost:11435`. Enables any OpenAI-compatible tool (OpenCode, Aider, Cline, Continue.dev) to use Antigravity's Gemini, Claude, and GPT models without additional API keys.

**Why it belongs here:** It's the missing glue layer that lets OpenCode users tap into Antigravity's full model suite.
