### PR TITLE
Add Untether — Telegram bridge with OpenCode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1025,6 +1025,15 @@
 </details>
 
 <details>
+  <summary><b>Untether</b> <img src="https://badgen.net/github/stars/littlebearapps/untether" height="14"/> - <i>Telegram bridge for remote task control</i></summary>
+  <blockquote>
+    Telegram bridge for OpenCode (and 5 other agents). Send tasks by voice or text, stream progress live, and manage sessions remotely. Supports 75+ providers via OpenCode's model system.
+    <br><br>
+    <a href="https://github.com/littlebearapps/untether">🔗 <b>View Repository</b></a>
+  </blockquote>
+</details>
+
+<details>
   <summary><b>Vibe Kanban</b> <img src="https://badgen.net/github/stars/BloopAI/vibe-kanban" height="14"/> - <i>Manage AI in parallel</i></summary>
   <blockquote>
     A Kanban board to manage and orchestrate AI coding agents in parallel.


### PR DESCRIPTION
Adds [Untether](https://github.com/littlebearapps/untether) to the Projects section.

Untether bridges OpenCode to Telegram for remote task management. Send tasks by voice or text, stream progress live, and manage sessions remotely.

- Supports 75+ providers via OpenCode's model system
- Voice note transcription
- Progress streaming
- Session resume
- Cost tracking

Also supports Claude Code, Codex, Pi, Gemini CLI, and Amp.

MIT licensed, Python 3.12+, `uv tool install untether`.