### PR TITLE
docs: add opencode-workaholic to plugins

### DIFF
--- a/data/plugins/opencode-workaholic.yaml
+++ b/data/plugins/opencode-workaholic.yaml
@@ -1,0 +1,7 @@
+name: OpenCode Workaholic
+repo: https://github.com/RoderickQiu/opencode-workaholic
+tagline: Enforce mandatory working time and prevents premature "done" responses
+description: |
+  - AI has an early-exit problem: it says "done" at 30 seconds while edge cases are untested, bugs remain, and docs are missing. 
+  - Workaholic enforces mandatory working time for AI until the timer hits zero.
+  - Blocks premature "done" responses until timer expire, and require AI to call checkout() to end the task.


### PR DESCRIPTION
## Submission Type

- [x] Plugin
- [ ] Project
- [ ] Theme
- [ ] Agent
- [ ] Resource

## Details

**Name:** OpenCode Workaholic
**Repository:** https://github.com/RoderickQiu/opencode-workaholic
**Tagline:** Enforce mandatory working time and prevents premature "done" responses

## Checklist

- [x] Relevant to OpenCode
- [x] Repository is public and accessible
- [x] Actively maintained
- [x] Not a duplicate
- [x] YAML file in correct folder (`data/{category}/`)
- [x] Filename is kebab-case (e.g., `my-plugin.yaml`)

## YAML Format

Create a file in `data/plugins/opencode-workaholic.yaml`:

```yaml
name: OpenCode Workaholic
repo: https://github.com/RoderickQiu/opencode-workaholic
tagline: Enforce mandatory working time and prevents premature "done" responses
description: |
  - AI has an early-exit problem: it says "done" at 30 seconds while edge cases are untested, bugs remain, and docs are missing. 
  - Workaholic enforces mandatory working time for AI until the timer hits zero.
  - Blocks premature "done" responses until timer expire, and require AI to call checkout() to end the task.
```

See [contributing.md](contributing.md) for full instructions.
