### PR TITLE
docs: add opencode-a2a to projects

### DIFF
--- a/data/projects/opencode-a2a-server.yaml
+++ b/data/projects/opencode-a2a-server.yaml
@@ -1,0 +1,4 @@
+name: Opencode A2A Server
+repo: https://github.com/Intelligent-Internet/opencode-a2a-server
+tagline: Standardized A2A adapter layer for OpenCode.
+description: An adapter layer that exposes OpenCode as a standardized Agent-to-Agent service, enabling seamless cross-agent collaboration and automated workflows.

--- a/data/projects/opencode-a2a.yaml
+++ b/data/projects/opencode-a2a.yaml
@@ -1,4 +1,4 @@
 name: Opencode A2A
 repo: https://github.com/Intelligent-Internet/opencode-a2a
-tagline: Standardized A2A adapter layer for OpenCode.
-description: An adapter layer that exposes OpenCode as a standardized Agent-to-Agent service, enabling seamless cross-agent collaboration and automated workflows.
+tagline: Full A2A Protocol support for OpenCode.
+description: A production-ready A2A Protocol implementation that exposes OpenCode as a standardized Agent-to-Agent service, enabling seamless cross-agent collaboration and automated workflows.

--- a/data/projects/opencode-a2a.yaml
+++ b/data/projects/opencode-a2a.yaml
@@ -1,4 +1,4 @@
-name: Opencode A2A Server
-repo: https://github.com/Intelligent-Internet/opencode-a2a-server
+name: Opencode A2A
+repo: https://github.com/Intelligent-Internet/opencode-a2a
 tagline: Standardized A2A adapter layer for OpenCode.
 description: An adapter layer that exposes OpenCode as a standardized Agent-to-Agent service, enabling seamless cross-agent collaboration and automated workflows.


### PR DESCRIPTION
Please review and add the opencode-a2a to the curated list. It provides a standardized Agent-to-Agent (A2A) adapter layer for OpenCode, bridging the gap for multi-agent automated collaboration.