### PR TITLE
docs: add command-inject plugin

### DIFF
--- a/data/plugins/command-inject.yaml
+++ b/data/plugins/command-inject.yaml
@@ -1,0 +1,4 @@
+name: Command Inject
+repo: https://github.com/shihyuho/opencode-command-inject
+tagline: Auto-inject project commands into OpenCode
+description: Automatically discovers and injects Makefile targets, npm/pnpm/yarn/bun scripts, and local skills at startup. Type / to see and run all project commands.


### PR DESCRIPTION
## Submission Type

- [x] Plugin
- [ ] Project
- [ ] Theme
- [ ] Agent
- [ ] Resource

## Details

**Name:** opencode-command-inject  
**Repository:** https://github.com/shihyuho/opencode-command-inject  
**Tagline:** Auto-inject project commands into OpenCode

## Checklist

- [x] Relevant to OpenCode
- [x] Repository is public and accessible
- [x] Actively maintained
- [x] Not a duplicate
- [x] YAML file in correct folder (`data/plugins/`)
- [x] Filename is kebab-case (e.g., `my-plugin.yaml`)

## YAML Format

Create a file in `data/plugins/command-inject.yaml`:

name: Command Inject
repo: https://github.com/shihyuho/opencode-command-inject
tagline: Auto-inject project commands into OpenCode
description: |
  Automatically discovers and injects Makefile targets, npm/pnpm/yarn/bun scripts, and local skills at startup.
  Type `/` to see and run all project commands directly from OpenCode's command palette.