### PR TITLE
Add opencode-image-compact plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,15 @@
 </details>
 
 <details>
+  <summary><b>Image Compact</b> <img src="https://badgen.net/github/stars/JlMoreno00/opencode-image-compact" height="14"/> - <i>Auto-compress oversized images</i></summary>
+  <blockquote>
+    Automatically compresses image attachments that exceed Anthropic's 5 MB base64 limit. Intercepts paste, drag-drop, and read-tool images before the API call, resizing and recompressing with Sharp so oversized screenshots no longer break sessions.
+    <br><br>
+    <a href="https://github.com/JlMoreno00/opencode-image-compact">🔗 <b>View Repository</b></a>
+  </blockquote>
+</details>
+
+<details>
   <summary><b>Kilo Gateway Auth</b> <img src="https://badgen.net/github/stars/JungHoonGhae/opencode-kilo-auth" height="14"/> - <i>Kilo Gateway provider</i></summary>
   <blockquote>
     Adds Kilo Gateway provider support to OpenCode.


### PR DESCRIPTION
## Summary

Adds **opencode-image-compact** to the plugins list — an OpenCode plugin that automatically compresses oversized image attachments before they hit Anthropic's 5 MB base64 limit.

- **What it solves**: Paste/drag-drop screenshots and read-tool images that exceed 5 MB base64 break sessions with `image exceeds 5 MB maximum` errors
- **How it works**: Intercepts images via `experimental.chat.messages.transform` hook, resizes with Sharp, and replaces the payload before the API call
- **npm**: [`opencode-image-compact`](https://www.npmjs.com/package/opencode-image-compact)
- **Repo**: https://github.com/JlMoreno00/opencode-image-compact