### PR TITLE
docs: add codewalk to projects

### DIFF
--- a/data/projects/codewalk.yaml
+++ b/data/projects/codewalk.yaml
@@ -1,0 +1,4 @@
+name: CodeWalk
+repo: https://github.com/verseles/codewalk
+tagline: Native cross-platform Flutter client for OpenCode server mode
+description: A fast, native Flutter client for OpenCode server mode with realtime streaming chat, speech-to-text on all platforms, multi-server profiles, model selection, and a Material 3 responsive UI for Linux, macOS, Windows, Web, and Android.


### PR DESCRIPTION
Add CodeWalk to the Projects list.

## Details

- **name:** CodeWalk
- **repo:** https://github.com/verseles/codewalk
- **tagline:** Native cross-platform Flutter client for OpenCode server mode
- **description:** A fast, native Flutter client for OpenCode server mode with realtime streaming chat, speech-to-text on all platforms, multi-server profiles, model selection, and a Material 3 responsive UI for Linux, macOS, Windows, Web, and Android.

CodeWalk is a native cross-platform client for OpenCode server mode, built with Flutter. It qualifies under all entry requirements: relevant to OpenCode, public repo, actively maintained, unique entry, and all required YAML fields included.