### PR TITLE
Add AgenTopology

### DIFF
--- a/README.md
+++ b/README.md
@@ -764,6 +764,15 @@
 <br>
 
 <details>
+  <summary><b>AgenTopology</b> <img src="https://badgen.net/github/stars/agentopology/agentopology" height="14"/> - <i>Declarative multi-agent topology language</i></summary>
+  <blockquote>
+    Generate platform configs for OpenCode/OpenClaw and 6 other platforms (Claude Code, Codex, Gemini CLI, Copilot CLI, Kiro) from a single declarative .at file. Define agents, flows, gates, hooks, and group chats. Ships with a Claude Code skill and interactive visualizer. Apache 2.0.
+    <br><br>
+    <a href="https://github.com/agentopology/agentopology">🔗 <b>View Repository</b></a>
+  </blockquote>
+</details>
+
+<details>
   <summary><b>Agent of Empires</b> <img src="https://badgen.net/github/stars/njbrake/agent-of-empires" height="14"/> - <i>Multi-session TUI for OpenCode</i></summary>
   <blockquote>
     A terminal UI for managing multiple OpenCode sessions in tmux with git worktree integration and Docker sandboxing.


### PR DESCRIPTION
## Summary

- Adds [AgenTopology](https://github.com/agentopology/agentopology) to the **Projects** section
- AgenTopology is a declarative language for multi-agent systems — write a single `.at` file and generate configs for OpenCode/OpenClaw plus 6 other CLI platforms (Claude Code, Codex, Gemini CLI, Copilot CLI, Kiro)
- Ships with parser, validator, CLI, interactive visualizer, and Claude Code skill
- Apache 2.0 licensed

Placed alphabetically before "Agent of Empires", matching the existing entry format exactly.