### PR TITLE
Add Worktree Memory Sync plugin

### DIFF
--- a/data/plugins/worktree-memory-sync.yaml
+++ b/data/plugins/worktree-memory-sync.yaml
@@ -1,0 +1,4 @@
+name: Worktree Memory Sync
+repo: https://github.com/Edison-A-N/opencode-worktree-memory-sync
+tagline: Auto-sync memory to git worktrees
+description: Automatically copies .opencode/memory/ from the main repository into new git worktrees on session init. Detects worktrees via the .git file, resolves the main repo, and syncs memory files only when the destination is empty — so it never overwrites your changes.


### PR DESCRIPTION
## Summary

Adds **[Worktree Memory Sync](https://github.com/Edison-A-N/opencode-worktree-memory-sync)** to the Plugins section.

### What it does

When you create a new git worktree via opencode's `/worktree` command, `.opencode/memory/` files from the main repo are **not** carried over — meaning the AI loses all accumulated project context in the new worktree.

This plugin fixes that by automatically syncing memory files on session init:

- Detects if the current directory is a git worktree (via `.git` file)
- Resolves the main repository path
- Copies `.opencode/memory/` into the worktree (only when destination is empty, never overwrites)

### Install

```json
{
  "plugin": ["opencode-worktree-memory-sync"]
}
```

**npm**: [`opencode-worktree-memory-sync`](https://www.npmjs.com/package/opencode-worktree-memory-sync)
**GitHub**: [`Edison-A-N/opencode-worktree-memory-sync`](https://github.com/Edison-A-N/opencode-worktree-memory-sync)