### PR TITLE
docs: add session-coherence and claude-learn to projects

### DIFF
--- a/data/projects/claude-learn.yaml
+++ b/data/projects/claude-learn.yaml
@@ -1,0 +1,4 @@
+name: Claude Learn
+repo: https://github.com/OutcomeFocusAi/claude-learn
+tagline: Self-improving behavioral playbook plugin for Claude Code
+description: Self-improving behavioral playbook plugin for Claude Code. Captures corrections, failures, and discoveries as scored rules that strengthen or decay over sessions — a closed feedback loop for continuous improvement.

--- a/data/projects/session-coherence.yaml
+++ b/data/projects/session-coherence.yaml
@@ -1,0 +1,4 @@
+name: Session Coherence
+repo: https://github.com/OutcomeFocusAi/session-coherence
+tagline: Cross-tool session memory for AI coding assistants
+description: Cross-tool session memory for AI coding assistants. One markdown chronicle shared by 9 tools (Claude Code, Cursor, Codex, Gemini CLI, Aider, and more). Zero dependencies, ~300 token fixed cost, 100% local.


### PR DESCRIPTION
## Summary
- Adds **[Session Coherence](https://github.com/OutcomeFocusAi/session-coherence)** — Cross-tool session memory for AI coding assistants. One markdown chronicle shared by 9 tools (Claude Code, Cursor, Codex, Gemini CLI, Aider, and more). Zero dependencies, ~300 token fixed cost, 100% local.
- Adds **[Claude Learn](https://github.com/OutcomeFocusAi/claude-learn)** — Self-improving behavioral playbook plugin for Claude Code. Captures corrections, failures, and discoveries as scored rules that strengthen or decay over sessions.

Both entries are added as YAML files in `data/projects/` per the contributing guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)