### PR TITLE
docs: add lavi to themes

### DIFF
--- a/data/themes/lavi.yaml
+++ b/data/themes/lavi.yaml
@@ -1,0 +1,4 @@
+name: Lavi
+repo: https://github.com/b0o/lavi/tree/main/contrib/opencode
+tagline: A soft and sweet colorscheme for Opencode and 15+ other apps
+description: A soft, sweet dark theme for Opencode with rich purple tones and carefully tuned syntax and diff colors. Part of the Lavi colorscheme family, which also provides matching themes for Neovim, Alacritty, Ghostty, Kitty, Wezterm, Zellij, and other tools, with Nix flake and home-manager support.


### PR DESCRIPTION
## Submission Type

- [ ] Plugin
- [ ] Project
- [x] Theme
- [ ] Agent
- [ ] Resource

## Details

**Name:** Lavi
**Repository:** https://github.com/b0o/lavi/tree/main/contrib/opencode
**Tagline:** A soft and sweet colorscheme for Opencode and 15+ other apps

## Checklist

- [x] Relevant to OpenCode
- [x] Repository is public and accessible
- [x] Actively maintained
- [x] Not a duplicate
- [x] YAML file in correct folder (`data/themes/`)
- [x] Filename is kebab-case (`lavi.yaml`)

## YAML Format

```yaml
name: Lavi
repo: https://github.com/b0o/lavi/tree/main/contrib/opencode
tagline: A soft and sweet colorscheme for Opencode and 15+ other apps
description: A soft, sweet dark theme for Opencode with rich purple tones and carefully tuned syntax and diff colors. Part of the Lavi colorscheme family, which also provides matching themes for Neovim, Alacritty, Ghostty, Kitty, Wezterm, Zellij, and other tools, with Nix flake and home-manager support.