### PR TITLE
docs: add opencode-token-tracker to plugins

### DIFF
--- a/data/plugins/opencode-token-tracker.yaml
+++ b/data/plugins/opencode-token-tracker.yaml
@@ -1,0 +1,4 @@
+name: OpenCode Token Tracker
+repo: https://github.com/eserete/opencode-token-tracker
+tagline: Real-time token usage, cost, and latency tracking for every AI request in OpenCode
+description: Displays a toast after each AI response with input/output tokens, cache hits, reasoning tokens, response latency, per-message cost, cumulative session cost, model identifier, and request count. Automatically aggregates tokens from subagent sessions spawned via the Task tool. Zero config — drop the file in and it works.


### PR DESCRIPTION
## Summary

- Adds `opencode-token-tracker` plugin to `data/plugins/`
- Real-time token usage, cost, and latency tracking displayed as a toast after each AI response
- Subagent-aware: automatically aggregates tokens from child sessions spawned via the Task tool
- Zero config — drop the file in and it works

## Checklist

- [x] Relevant — directly related to OpenCode
- [x] Public — repository is publicly accessible
- [x] Maintained — active commits within the last 6 months
- [x] Unique — not a duplicate of an existing entry
- [x] Complete — all required fields included