### PR TITLE
Add clwnd to Projects

### DIFF
--- a/data/projects/clwnd.yaml
+++ b/data/projects/clwnd.yaml
@@ -1,4 +1,4 @@
 name: clwnd
 repo: https://github.com/adiled/clwnd
-tagline: "Use your Claude Code subscription in OpenCode with full tool control"
-description: "Bridges Claude Code CLI into OpenCode as a provider — persistent process, MCP-based file tools with directory enforcement, brokered tool execution for native OpenCode UI, session continuity, and permission forwarding. Uses your existing Claude subscription auth."
+tagline: "take back what is yours"
+description: "clwnd unlocks claude code subscriptions inside opencode (usage-compliant). With harness stitching and clwnd's own runtime, you can opt-in to more low level cross-cutting control."

--- a/data/projects/clwnd.yaml
+++ b/data/projects/clwnd.yaml
@@ -1,0 +1,4 @@
+name: clwnd
+repo: https://github.com/adiled/clwnd
+tagline: "Use your Claude Code subscription in OpenCode with full tool control"
+description: "Bridges Claude Code CLI into OpenCode as a provider — persistent process, MCP-based file tools with directory enforcement, brokered tool execution for native OpenCode UI, session continuity, and permission forwarding. Uses your existing Claude subscription auth."

--- a/data/projects/clwnd.yaml
+++ b/data/projects/clwnd.yaml
@@ -1,4 +1,4 @@
 name: clwnd
 repo: https://github.com/adiled/clwnd
 tagline: "take back what is yours"
-description: "clwnd unlocks claude code subscriptions inside opencode (usage-compliant). With harness stitching and clwnd's own runtime, you can opt-in to more low level cross-cutting control."
+description: "clwnd unlocks claude code subscriptions inside opencode (usage-compliant). With harness stitching and clwnd's own runtime, you can opt-in to more low level cross-cutting control over your agentic workflows."

--- a/data/projects/clwnd.yaml
+++ b/data/projects/clwnd.yaml
@@ -1,4 +1,4 @@
 name: clwnd
 repo: https://github.com/adiled/clwnd
 tagline: "take back what is yours"
-description: "clwnd unlocks claude code subscriptions inside opencode (usage-compliant). With harness stitching and clwnd's own runtime, you can opt-in to more low level cross-cutting control over your agentic workflows."
+description: "clwnd unlocks claude code subscriptions inside opencode (usage-compliant). With harness stitching and clwnd's own runtime, you can opt-in to more accessible low level cross-cutting control over your agentic workflows."


### PR DESCRIPTION
## New Entry

- **Category**: Projects
- **Name**: clwnd
- **Repo**: https://github.com/adiled/clwnd

clwnd lets you use your Claude Code subscription inside opencode. It streams Claude Code sessions via a runtime separate from opencode, with better security, performance and compliance framework through isolation.

In terms of UX: You can pick any claude models from the `opencode-clwnd` provider, and continue without worry. The sessions are being tracked in both claude and opencode, with best-fitting OpenCode feature compatibility, and potential for personalized enhancements.

clwnd's runtime gives you control over file system operations, governed by opencode's permission system. opencode backend (database, servers) and client (TUI, desktop, web) compatibility remains intact.