### PR TITLE
Add Termly — free native mobile app for OpenCode

### DIFF
--- a/data/projects/termly.yaml
+++ b/data/projects/termly.yaml
@@ -1,0 +1,4 @@
+name: Termly
+repo: https://termly.dev/
+tagline: Control Claude Code, OpenCode, and other CLI AI assistants from iPhone, iPad, or Android
+description: Free native mobile app that connects to OpenCode, Claude Code, Gemini CLI, and other terminal AI tools via a zero-knowledge WebSocket relay. Pairs in under 60 seconds via QR code. E2E encrypted (AES-256-GCM), no subscriptions, no usage limits.


### PR DESCRIPTION
## Summary

Adds [Termly](https://termly.dev/) to the **Projects** section via `data/projects/termly.yaml`.

Termly is a free native iOS and Android app that lets you monitor and control OpenCode (and other CLI AI assistants like Claude Code, Gemini CLI) remotely from your phone. It connects via a zero-knowledge WebSocket relay — the server never decrypts your data. Pairs in under 60 seconds via QR code. No subscriptions, no usage limits.