### PR TITLE
feat: add opencode-llm-proxy plugin

### DIFF
--- a/data/plugins/llm-proxy.yaml
+++ b/data/plugins/llm-proxy.yaml
@@ -1,0 +1,4 @@
+name: LLM Proxy
+repo: https://github.com/KochC/opencode-llm-proxy
+tagline: OpenAI / Anthropic / Gemini API gateway
+description: Starts a local HTTP server that proxies OpenAI, Anthropic, and Google Gemini API requests to any model configured in OpenCode. Use Open WebUI, LangChain, the OpenAI SDK, or any other tool without reconfiguring your models.


### PR DESCRIPTION
## What is this?

[opencode-llm-proxy](https://github.com/KochC/opencode-llm-proxy) is an OpenCode plugin that starts a local HTTP server (`http://127.0.0.1:4010`) which translates between multiple API formats and any model configured in OpenCode.

## Why it belongs here

- It's an OpenCode plugin (loaded via the `plugin` key in `opencode.json`)
- Published on npm: [`opencode-llm-proxy`](https://www.npmjs.com/package/opencode-llm-proxy)
- 112 tests, MIT license, actively maintained

## Supported API formats

| Format | Endpoint |
|---|---|
| OpenAI Chat Completions | `POST /v1/chat/completions` |
| OpenAI Responses API | `POST /v1/responses` |
| Anthropic Messages API | `POST /v1/messages` |
| Google Gemini | `POST /v1beta/models/:model:generateContent` |

## Quickstart

```bash
npm install opencode-llm-proxy
```

```json
{ "plugin": ["opencode-llm-proxy"] }
```