### PR TITLE
docs: add magic-context to plugins

### DIFF
--- a/data/plugins/magic-context.yaml
+++ b/data/plugins/magic-context.yaml
@@ -1,0 +1,4 @@
+name: Magic Context
+repo: https://github.com/cortexkit/opencode-magic-context
+tagline: Lossless context management with background compression
+description: Cache-aware context management that keeps long sessions productive. Background historian compresses old conversation into structured compartments while you keep working. Includes cross-session project memory, unified search across history/memories/facts, overnight dreamer for memory maintenance, and prompt-cache-safe deferred operations.


### PR DESCRIPTION
## Summary

Adds [Magic Context](https://github.com/cortexkit/opencode-magic-context) to the plugins list.

**What it does:** Cache-aware context management for long OpenCode sessions. A background historian compresses old conversation into structured compartments while the agent keeps working — no context window pressure, no lost history.

**Key features:**
- Background historian + compressor for lossless context compression
- Cross-session project memory with semantic + FTS search
- Unified `ctx_search` across memories, facts, and raw conversation history
- Prompt-cache-safe deferred operations (never busts LLM providers' cache unnecessarily)
- Overnight dreamer for automated memory maintenance
- All via `/ctx-*` commands and agent tools

Published on npm as `@cortexkit/opencode-magic-context`.