### PR TITLE
Add opencode-omoc-swarm plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,15 @@
 </details>
 
 <details>
+  <summary><b>opencode-omoc-swarm</b> <img src="https://badgen.net/github/stars/Delqhi/opencode-omoc-swarm" height="14"/> - <i>Tmux-first subagent workflows with fan-out, messaging, and MAX-mode git worktrees.</i></summary>
+  <blockquote>
+    Subagent workflow plugin for OpenCode with tmux side-by-side sessions, agent messaging, parallel fan-out, and MAX-mode best-of-n editing via isolated git worktrees. Built in the OpenSIN ecosystem.
+    <br><br>
+    <a href="https://github.com/Delqhi/opencode-omoc-swarm">🔗 <b>View Repository</b></a>
+  </blockquote>
+</details>
+
+<details>
   <summary><b>opencode-plugin-otel</b> <img src="https://badgen.net/github/stars/DEVtheOPS/opencode-plugin-otel" height="14"/> - <i>OpenTelemetry telemetry exporter for opencode sessions, mirroring Claude Code monitoring signals</i></summary>
   <blockquote>
     Exports metrics, logs, and traces from opencode sessions via OTLP/gRPC to any OpenTelemetry-compatible backend (Datadog, Honeycomb, Grafana Cloud, etc.). Instruments session lifecycle, token usage, cost, tool durations, and git commits — mirroring the same signals as Claude Code's monitoring.

--- a/data/plugins/opencode-omoc-swarm.yaml
+++ b/data/plugins/opencode-omoc-swarm.yaml
@@ -1,0 +1,14 @@
+name: opencode-omoc-swarm
+repo: https://github.com/Delqhi/opencode-omoc-swarm
+tagline: Tmux-first subagent workflows with fan-out, messaging, and MAX-mode git worktrees.
+description: Subagent workflow plugin for OpenCode with tmux side-by-side sessions, agent messaging, parallel fan-out, and MAX-mode best-of-n editing via isolated git worktrees. Built in the OpenSIN ecosystem.
+scope:
+  - global
+  - project
+tags:
+  - orchestration
+  - tmux
+  - git-worktree
+  - subagents
+  - opensin
+homepage: https://opensin.ai


### PR DESCRIPTION
## Why
Add `opencode-omoc-swarm` to awesome-opencode as a community OpenCode plugin.

## What
- adds `data/plugins/opencode-omoc-swarm.yaml`
- regenerates `README.md`

## Plugin summary
Tmux-first subagent workflows with fan-out, messaging, and MAX-mode git worktrees. Built in the OpenSIN ecosystem.