### PR TITLE
Add agent-dotfiles to projects

### DIFF
--- a/data/projects/agent-dotfiles.yaml
+++ b/data/projects/agent-dotfiles.yaml
@@ -1,0 +1,4 @@
+name: agent-dotfiles
+repo: https://github.com/saqibameen/agent-dotfiles
+tagline: Write AI coding rules once, sync to every agent
+description: Write AI coding rules once, sync to every agent. Supports Command Code, Claude Code, Cursor, Copilot, Codex, and OpenCode.


### PR DESCRIPTION
## Summary

- Adds [agent-dotfiles](https://github.com/saqibameen/agent-dotfiles) to the Projects section
- Write AI coding rules once, sync to every agent. Supports Claude Code, Cursor, Copilot, Codex, OpenCode, Windsurf, Gemini CLI, Kilo Code.

## Test plan

- [x] YAML entry follows the required schema (name, repo, tagline, description)
- [x] `npm run validate` passes with all 118 entries