### PR TITLE
Add bx — macOS sandbox for AI coding agents

### DIFF
--- a/data/projects/bx.yaml
+++ b/data/projects/bx.yaml
@@ -1,0 +1,4 @@
+name: bx
+repo: https://github.com/holtwick/bx-mac
+tagline: macOS file-system sandbox for AI coding agents
+description: Launch OpenCode, VSCode, Claude Code, or any command in a macOS sandbox (sandbox-exec). Dynamically blocks access to everything except the project directory — no containers, no VMs, just one command.


### PR DESCRIPTION
## Summary
- Adds [bx](https://github.com/holtwick/bx-mac) to the Projects section
- bx wraps any application (OpenCode, VSCode, Claude Code, terminals, arbitrary commands) in a macOS `sandbox-exec` sandbox that dynamically blocks file access to everything except the specified project directory — no containers, no VMs, just one command