### PR TITLE
docs: add opencode-preview to plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,15 @@
 </details>
 
 <details>
+  <summary><b>Opencode Preview</b> <img src="https://badgen.net/github/stars/Edison-A-N/opencode-preview" height="14"/> - <i>Instant multi-format file preview with live reload</i></summary>
+  <blockquote>
+    Auto-starts a preview server for Markdown, DrawIO, HTML, CSV, and 40+ code languages. Features live reload via WebSocket, dark mode, multi-project support, file browser with sidebar navigation, and TUI integration. Zero config — one line of JSON to install.
+    <br><br>
+    <a href="https://github.com/Edison-A-N/opencode-preview">🔗 <b>View Repository</b></a>
+  </blockquote>
+</details>
+
+<details>
   <summary><b>OpenCode ntfy.sh</b> <img src="https://badgen.net/github/stars/lannuttia/opencode-ntfy.sh" height="14"/> - <i>Push notifications to keep you in the know, even when you're on the go.</i></summary>
   <blockquote>
     An OpenCode plugin that adds push notifications through ntfy.sh.

--- a/data/plugins/opencode-preview.yaml
+++ b/data/plugins/opencode-preview.yaml
@@ -1,0 +1,4 @@
+name: OpenCode Preview
+repo: https://github.com/Edison-A-N/opencode-preview
+tagline: Auto-start file preview server with live reload
+description: Preview Markdown, DrawIO, HTML, CSV, and 40+ code languages in the browser with live reload. Multi-project support, git worktree awareness, sidebar navigation, and TUI integration.


### PR DESCRIPTION
## Summary

- Adds **opencode-preview** plugin to the registry
- Auto-starts a file preview server for Markdown, DrawIO, HTML, CSV, and 40+ code languages
- Features: live reload (WebSocket), multi-project support, git worktree awareness, sidebar navigation, TUI integration, dark mode

**Repo**: https://github.com/Edison-A-N/opencode-preview