### PR TITLE
docs: add kibi-opencode plugin entry

### DIFF
--- a/data/plugins/kibi-opencode.yaml
+++ b/data/plugins/kibi-opencode.yaml
@@ -1,0 +1,28 @@
+name: kibi-opencode
+repo: https://github.com/Looted/kibi
+tagline: Repo-local, branch-scoped knowledge and traceability for OpenCode
+description: |
+  Plugin-first entry point into the Kibi stack for OpenCode users. It adds context-aware
+  guidance, routes durable code comments toward Kibi artifacts, runs non-blocking background
+  sync and targeted validation checks, and helps keep repo knowledge branch-local and queryable.
+scope:
+  - project
+tags:
+  - opencode
+  - plugin
+  - mcp
+  - traceability
+installation: |
+  ## Install
+  Add the plugin to your project `opencode.json`:
+
+  ```json
+  {
+    "$schema": "https://opencode.ai/config.json",
+    "plugin": ["kibi-opencode"]
+  }
+  ```
+
+  OpenCode installs npm plugins declared in `plugin` automatically at startup.
+
+  After startup, run `/init-kibi` in the repository to bootstrap the Kibi knowledge base.


### PR DESCRIPTION
## Summary
- add `kibi-opencode` under `data/plugins/` as a plugin-first entry for the Kibi stack
- highlight evidence-backed capabilities: context-aware guidance, durable comment routing, background sync, and targeted validation
- include a short installation block using the documented `opencode.json` plugin declaration and `/init-kibi`

## Why this fits awesome-opencode
`kibi-opencode` is the OpenCode entry point into Kibi, a repo-local and branch-local knowledge base for software projects. The plugin is directly relevant to OpenCode users because it adds contextual guidance inside sessions, routes durable code comments toward Kibi artifacts, and supports non-blocking knowledge-base sync workflows.

## Validation
- ran `node scripts/validate.js`
- ran `node scripts/generate-readme.js`
- confirmed the PR diff is limited to `data/plugins/kibi-opencode.yaml`