### PR TITLE
docs: add opencode-ccs-sync plugin

### DIFF
--- a/data/plugins/opencode-ccs-sync.yaml
+++ b/data/plugins/opencode-ccs-sync.yaml
@@ -1,0 +1,4 @@
+name: OpenCode CCS Sync
+repo: https://github.com/JasonLandbridge/opencode-ccs-sync
+tagline: CCS to OpenCode sync
+description: An OpenCode plugin that reads your Claude Code Switch (CCS) configuration and automatically syncs the providers into your OpenCode config.

--- a/data/plugins/opencode-ccs-sync.yaml
+++ b/data/plugins/opencode-ccs-sync.yaml
@@ -1,4 +1,4 @@
-name: OpenCode CCS Sync
+name: Claude Code Switch (CCS) OpenCode Sync
 repo: https://github.com/JasonLandbridge/opencode-ccs-sync
-tagline: CCS to OpenCode sync
+tagline: Claude Code Switch (CCS) to OpenCode sync
 description: An OpenCode plugin that reads your Claude Code Switch (CCS) configuration and automatically syncs the providers into your OpenCode config.


### PR DESCRIPTION
## Submission Type

- [x] Plugin
- [ ] Project
- [ ] Theme
- [ ] Agent
- [ ] Resource

## Details

**Name:** OpenCode CCS Sync
**Repository:** https://github.com/JasonLandbridge/opencode-ccs-sync
**Tagline:** CCS to OpenCode sync

## Summary

An OpenCode plugin that reads your Claude Code Switch (CCS) configuration and automatically syncs the providers into your OpenCode config.

## Checklist

- [x] Relevant to OpenCode
- [x] Repository is public and accessible
- [x] Actively maintained
- [x] Not a duplicate
- [x] YAML file in correct folder (`data/plugins/`)
- [x] Filename is kebab-case (`opencode-ccs-sync.yaml`)

## YAML Format

Create a file in `data/plugins/opencode-ccs-sync.yaml`:

```yaml
name: OpenCode CCS Sync
repo: https://github.com/JasonLandbridge/opencode-ccs-sync
tagline: CCS to OpenCode sync
description: An OpenCode plugin that reads your Claude Code Switch (CCS) configuration and automatically syncs the providers into your OpenCode config.
```