### PR TITLE
docs: add Global Chat to projects

### DIFF
--- a/data/projects/global-chat.yaml
+++ b/data/projects/global-chat.yaml
@@ -1,0 +1,4 @@
+name: Global Chat
+repo: https://github.com/pumanitro/global-chat
+tagline: Cross-protocol AI agent discovery with MCP server
+description: Discovery layer for AI agents — a protocol-agnostic directory that aggregates agents across MCP, A2A, agents.txt, and 9+ other protocols. Ships an MCP server (@global-chat/mcp-server) for programmatic access from opencode and other MCP clients. Includes a searchable directory of 100,000+ agents and a free agents.txt validator.


### PR DESCRIPTION
Adds [Global Chat](https://github.com/pumanitro/global-chat) to the Projects section.

**What it does:** Cross-protocol AI agent discovery platform that aggregates agents across MCP, A2A, agents.txt, and 9+ other protocols. Ships an MCP server (`@global-chat/mcp-server`) for programmatic access from opencode and other MCP clients.

**Why it fits:** The MCP server lets opencode users search and discover AI agents across 15+ registries directly from their terminal session. It also includes a searchable directory of 100,000+ agents and a free agents.txt validator/linter.

- [x] Relevant — MCP server works natively with opencode
- [x] Public — repo is public
- [x] Maintained — active commits
- [x] Unique — no existing agent discovery entry
- [x] Complete — all YAML fields included