### PR TITLE
docs: add opencode-copilot-usage to plugins

### DIFF
--- a/data/plugins/opencode-copilot-budget.yaml
+++ b/data/plugins/opencode-copilot-budget.yaml
@@ -1,0 +1,4 @@
+name: Copilot Budget
+repo: https://github.com/bhaskarmelkani/opencode-copilot-budget
+tagline: GitHub Copilot premium budget in the TUI sidebar
+description: Shows your GitHub Copilot premium request budget at the top of the OpenCode TUI sidebar. Displays a progress bar, used/remaining requests, overage amount, and reset date. Only visible when the active provider is github-copilot. Auto-refreshes after each AI response.

--- a/data/plugins/opencode-copilot-usage.yaml
+++ b/data/plugins/opencode-copilot-usage.yaml
@@ -1,4 +1,0 @@
-name: Copilot Usage
-repo: https://github.com/bhaskarmelkani/opencode-copilot-usage
-tagline: GitHub Copilot premium quota in the TUI sidebar
-description: Shows your GitHub Copilot premium request quota at the top of the OpenCode TUI sidebar. Displays used/remaining requests, overage amount, and reset date. Only visible when the active provider is github-copilot. Auto-refreshes after each AI response.

--- a/data/plugins/opencode-copilot-usage.yaml
+++ b/data/plugins/opencode-copilot-usage.yaml
@@ -1,0 +1,4 @@
+name: Copilot Usage
+repo: https://github.com/bhaskarmelkani/opencode-copilot-usage
+tagline: GitHub Copilot premium quota in the TUI sidebar
+description: Shows your GitHub Copilot premium request quota at the top of the OpenCode TUI sidebar. Displays used/remaining requests, overage amount, and reset date. Only visible when the active provider is github-copilot. Auto-refreshes after each AI response.


### PR DESCRIPTION
## Summary

- Adds `opencode-copilot-usage` plugin to the plugins directory
- Shows GitHub Copilot premium request quota in the OpenCode TUI sidebar
- Auto-refreshes after each AI response; only visible when using the github-copilot provider

## Checklist

- [x] Relevant — directly related to OpenCode
- [x] Public — https://github.com/bhaskarmelkani/opencode-copilot-usage is public
- [x] Maintained — initial release
- [x] Unique — no existing Copilot quota sidebar plugin
- [x] Complete — all required YAML fields included