### PR TITLE
Add ocp to Projects

### DIFF
--- a/data/projects/ocp.yaml
+++ b/data/projects/ocp.yaml
@@ -1,0 +1,4 @@
+name: ocp
+repo: https://github.com/alvarosanchez/ocp
+tagline: Manage OpenCode config profiles in Git
+description: A CLI for switching OpenCode configuration profiles stored in Git repositories.


### PR DESCRIPTION
## Summary
- add `ocp` under `data/projects/`

## Why it fits
`ocp` is a CLI for managing OpenCode configuration profiles stored in Git repositories, so users can switch between OpenCode setups more reliably.

I believe it fits the Projects section as an OpenCode-focused utility. Happy to adjust or withdraw if it is outside the intended scope.

## Validation
- `npm run validate`
