### PR TITLE
docs: add SourceHarbor to projects

### DIFF
--- a/data/projects/sourceharbor.yaml
+++ b/data/projects/sourceharbor.yaml
@@ -1,0 +1,4 @@
+name: SourceHarbor
+repo: https://github.com/xiaojiou176-open/sourceharbor
+tagline: Source-first MCP knowledge control tower for watchlists, grounded search, and evidence-backed Ask.
+description: SourceHarbor helps terminal agent workflows turn YouTube, Bilibili, RSSHub, and RSS inputs into watchlists, briefings, grounded search, and Ask answers. It ships an MCP server plus public CLI and SDK surfaces, so Opencode-adjacent workflows can reuse the same source-first evidence layer through MCP or HTTP.


### PR DESCRIPTION
## Summary
- add SourceHarbor to the `data/projects` catalog
- describe it as a source-first MCP knowledge control tower that terminal agent workflows can reuse through MCP or HTTP

## Why
SourceHarbor is a public project with an MCP server plus CLI/SDK surfaces that coding-agent workflows can integrate with for watchlists, briefings, grounded search, and Ask answers.
