### PR TITLE
docs: add opencode-trace to plugins

### DIFF
--- a/data/plugins/opencode-trace.yaml
+++ b/data/plugins/opencode-trace.yaml
@@ -1,0 +1,12 @@
+name: opencode-trace
+repo: https://github.com/ljw1004/opencode-trace
+tagline: Capture raw json LLM requests+responses as jsonl traces, with interactive HTML viewer
+description: OpenCode plugin that logs raw provider request and response payloads to ~/opencode-trace as self-contained HTML files with an interactive viewer for debugging and inspection.
+scope:
+  - global
+tags:
+  - tracing
+  - debugging
+  - observability
+installation: |
+  Add `"@ljw1004/opencode-trace"` to the `plugin` array in `~/.config/opencode/opencode.json`.


### PR DESCRIPTION
## Submission Type

- [X] Plugin

## Details

**Name:** opencode-trace
**Repository:** https://github.com/ljw1004/opencode-trace
**Tagline:** Capture raw json LLM requests+responses as jsonl traces, with interactive HTML viewer

## Checklist

- [X] Relevant to OpenCode
- [X] Repository is public and accessible
- [X] Actively maintained
- [X] Not a duplicate
- [X] YAML file in correct folder (`data/{category}/`)
- [X] Filename is kebab-case (e.g., `my-plugin.yaml`)
