### PR TITLE
docs: add OpenCode Skills Collection to plugins

### DIFF
--- a/data/plugins/opencode-skills-collection.yml
+++ b/data/plugins/opencode-skills-collection.yml
@@ -1,0 +1,4 @@
+name: OpenCode Skills Collection
+repo: https://github.com/FrancoStino/opencode-skills-collection
+tagline: OpenCode Skills Collection ships a pre-bundled snapshot of 1000+ universal skills for the OpenCode.
+description: Instead of loading every skill into the AI context at startup — which would consume ~80k tokens and cause compaction loops — the plugin uses a SkillPointer architecture: skills are organized into categories inside a hidden vault and only loaded into context on demand.


### PR DESCRIPTION
## Submission Type

- [x] Plugin
- [ ] Project
- [ ] Theme
- [ ] Agent
- [ ] Resource

## Details

**Name:** OpenCode Skills Collection
**Repository:** https://github.com/FrancoStino/opencode-skills-collection
**Tagline:** OpenCode Skills Collection ships a pre-bundled snapshot of 1000+ universal skills for the OpenCode CLI.

Instead of loading every skill into the AI context at startup — which would consume ~80k tokens and cause compaction loops — the plugin uses a SkillPointer architecture: skills are organized into categories inside a hidden vault and only loaded into context on demand.

## Checklist

- [ ] Relevant to OpenCode
- [x] Repository is public and accessible
- [x] Actively maintained
- [x] Not a duplicate
- [x] YAML file in correct folder (`data/{category}/`)
- [x] Filename is kebab-case (e.g., `my-plugin.yaml`)
