### PR TITLE
docs: add ProofTrail to projects

### DIFF
--- a/data/projects/prooftrail.yaml
+++ b/data/projects/prooftrail.yaml
@@ -1,0 +1,4 @@
+name: ProofTrail
+repo: https://github.com/xiaojiou176-open/prooftrail
+tagline: Browser evidence and recovery layer for OpenCode-aligned agent workflows
+description: Evidence-first browser automation project that helps OpenCode-style coding-agent workflows run a canonical browser path, keep retained proof, and recover before guesswork via governed API and MCP surfaces.


### PR DESCRIPTION
## Summary
- add `ProofTrail` under `data/projects/`
- position it as an evidence-first browser automation and recovery layer for OpenCode-aligned agent workflows
- keep the entry grounded in the current public README framing

## Why this fits
- the project README explicitly names OpenCode as one of the supported coding-agent ecosystems
- the repository is public and actively maintained
- the entry is submitted as a `Project`, matching the repo's current product shape
