### PR TITLE
docs: add prooftrail project entry

### DIFF
--- a/data/projects/prooftrail.yaml
+++ b/data/projects/prooftrail.yaml
@@ -1,0 +1,4 @@
+name: ProofTrail
+repo: https://github.com/xiaojiou176-open/prooftrail
+tagline: Governed browser-evidence layer for OpenCode and other coding-agent shells
+description: Evidence-first browser automation and recovery workspace with a local stdio MCP side road, retained proof bundles, and honest install contracts for OpenCode-adjacent workflows.


### PR DESCRIPTION
## Summary
- add a `data/projects/prooftrail.yaml` entry for ProofTrail
- position it as an OpenCode-adjacent project, not as a plugin or theme

## Why this fits
- ProofTrail is directly relevant to OpenCode-style coding-agent workflows because it provides a governed browser-evidence and recovery layer behind those shells
- the repo is public and actively maintained
- the honest lane here is `project`, not `plugin`

## Boundaries
- this PR does not claim ProofTrail is an official OpenCode plugin
- this PR does not claim a hosted MCP endpoint
- this PR keeps the entry scoped to the public project surface
