### PR TITLE
docs: add Prompt Switchboard and Provenote projects

### DIFF
--- a/data/projects/prompt-switchboard.yaml
+++ b/data/projects/prompt-switchboard.yaml
@@ -1,0 +1,13 @@
+name: Prompt Switchboard
+repo: https://github.com/xiaojiou176-open/multi-ai-sidepanel
+tagline: Browser-native AI compare workspace with an OpenCode-ready MCP packet
+description: A compare-first, local-first browser workspace that sends one prompt
+  across multiple AI tabs, keeps the trust boundary inside the browser, and ships
+  a checked-in OpenCode MCP starter bundle plus a publish-ready plugin scaffold
+  without pretending the plugin is already listed.
+tags:
+  - ai-compare
+  - browser
+  - mcp
+  - opencode
+  - workflow

--- a/data/projects/provenote.yaml
+++ b/data/projects/provenote.yaml
@@ -1,0 +1,13 @@
+name: Provenote
+repo: https://github.com/xiaojiou176-open/provenote
+tagline: Outcome-first research workbench with a tracked OpenCode MCP starter bundle
+description: A source-grounded note and draft workbench that keeps the first door
+  on structured outcomes, then layers a first-party MCP server and a checked-in
+  OpenCode starter bundle on top so OpenCode users can inspect notebooks, research
+  threads, and auditable runs without overstating plugin or marketplace status.
+tags:
+  - research
+  - notes
+  - mcp
+  - opencode
+  - knowledge-work


### PR DESCRIPTION
## Summary
- add Prompt Switchboard as an OpenCode-related project entry
- add Provenote as an outcome-first OpenCode-related project entry
- keep both entries in the curated project lane instead of overclaiming plugin listings

## Verification
- `npm run validate -- data/projects/prompt-switchboard.yaml data/projects/provenote.yaml`