### PR TITLE
docs: add OpenUI MCP Studio and Movi Organizer projects

### DIFF
--- a/data/projects/movi-organizer.yaml
+++ b/data/projects/movi-organizer.yaml
@@ -1,0 +1,4 @@
+name: Movi Organizer
+repo: https://github.com/xiaojiou176-open/movi-organizer
+tagline: Review-first local MCP workbench for file organization and batch workflow triage in coding-agent shells
+description: A review-first local MCP workflow for organizing files and batch work that exposes repo-owned OpenCode-compatible attach paths through its stdio server, dry-run safety model, and proof-first install materials instead of claiming a hosted or plugin-only surface.

--- a/data/projects/openui-mcp-studio.yaml
+++ b/data/projects/openui-mcp-studio.yaml
@@ -1,0 +1,4 @@
+name: OpenUI MCP Studio
+repo: https://github.com/xiaojiou176-open/openui-mcp-studio
+tagline: Local MCP-first UI generation and review workspace with checked-in OpenCode-compatible bundles
+description: A local-first UI generation and review workspace that ships a canonical stdio MCP server, repo-owned OpenCode-compatible starter bundles, and proof-first delivery flows for coding-agent workspaces without overstating hosted or marketplace status.


### PR DESCRIPTION
## Summary
- add an OpenUI MCP Studio project entry
- add a Movi Organizer project entry

## Why these fit
- both repositories expose repo-owned OpenCode-compatible local MCP install surfaces
- both are better represented as curated projects than as plugins or themes
- the entries stay honest about local-first / proof-first boundaries and do not claim hosted runtime or official plugin listing status

## Source repos
- xiaojiou176-open/openui-mcp-studio
- xiaojiou176-open/movi-organizer