### PR TITLE
docs: add SwarmVault to projects

### DIFF
--- a/data/projects/swarmvault.yaml
+++ b/data/projects/swarmvault.yaml
@@ -1,0 +1,4 @@
+name: SwarmVault
+repo: https://github.com/swarmclawai/swarmvault
+tagline: Local-first RAG knowledge base compiler with bundled skill and MCP server
+description: Turns raw docs, research, and code into a persistent markdown wiki, knowledge graph, and hybrid SQLite FTS + embeddings search. Ships a bundled skill (schema-first, graph-query-first conventions) and an MCP server, so it works with OpenCode, Claude Code, and Codex. Offline heuristic provider by default; optional Ollama for local embeddings.


### PR DESCRIPTION
Adding SwarmVault to the Projects section.

SwarmVault is a local-first RAG knowledge base compiler. It turns raw docs, research, and code into a persistent markdown wiki, knowledge graph, and hybrid SQLite FTS + embeddings search. It ships a bundled skill and MCP server, so it slots naturally into OpenCode alongside the other cross-agent tools already in this list.

- https://github.com/swarmclawai/swarmvault
- https://swarmvault.ai

License: MIT