### PR TITLE
Add Helium MCP — news bias, markets & ML options pricing

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,6 +656,15 @@
 </details>
 
 <details>
+  <summary><b>Helium MCP</b> <img src="https://badgen.net/github/stars/connerlambden/helium-mcp" height="14"/> - <i>News bias scoring, live markets & ML options pricing</i></summary>
+  <blockquote>
+    Remote MCP server with 9 tools — real-time news search with bias scoring across 5,000+ sources, live stock/ETF/crypto data with AI bull/bear cases, ML options pricing, balanced news synthesis, and meme search. Free tier, no API key needed. Works with OpenCode, Claude Code, Cursor, Codex, Gemini CLI, and any MCP client.
+    <br><br>
+    <a href="https://github.com/connerlambden/helium-mcp">🔗 <b>View Repository</b></a>
+  </blockquote>
+</details>
+
+<details>
   <summary><b>Zellij Namer</b> <img src="https://badgen.net/github/stars/24601/opencode-zellij-namer" height="14"/> - <i>Auto-rename Zellij sessions</i></summary>
   <blockquote>
     Keeps your Zellij session name in sync with your work.


### PR DESCRIPTION
## Summary

Adds [Helium MCP](https://github.com/connerlambden/helium-mcp) to the plugins section alongside Xquik as another MCP-based data skill.

Remote MCP server with 9 tools:
- Real-time news search with bias scoring across 15+ dimensions (5,000+ sources)
- Live stock/ETF/crypto data with AI-generated bull/bear cases
- ML-powered options fair value pricing
- Balanced multi-perspective news synthesis
- Semantic meme search

Free tier (50 queries), no API key required. Works with OpenCode, Claude Code, Cursor, Codex, Gemini CLI, and any MCP client.

Made with [Cursor](https://cursor.com)