### PR TITLE
docs: add opencode-session-recall to plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,15 @@
 </details>
 
 <details>
+  <summary><b>Opencode Session Recall</b> <img src="https://badgen.net/github/stars/rmk40/opencode-session-recall" height="14"/> - <i>Expose every stored session and project conversation to the agent</i></summary>
+  <blockquote>
+    Everything beyond the context window is still sitting in OpenCode's database. This plugin turns that inaccessible history into usable context for the agent across sessions, projects, tool outputs, and reasoning traces, with zero setup.
+    <br><br>
+    <a href="https://github.com/rmk40/opencode-session-recall">🔗 <b>View Repository</b></a>
+  </blockquote>
+</details>
+
+<details>
   <summary><b>Opencode Sessions</b> <img src="https://badgen.net/github/stars/malhashemi/opencode-sessions" height="14"/> - <i>Session management</i></summary>
   <blockquote>
     Session management plugin for OpenCode with multi-agent collaboration support.

--- a/data/plugins/opencode-session-recall.yaml
+++ b/data/plugins/opencode-session-recall.yaml
@@ -1,0 +1,8 @@
+name: Opencode Session Recall
+repo: https://github.com/rmk40/opencode-session-recall
+tagline: "Expose every stored session and project conversation to the agent"
+description: "Everything beyond the context window is still sitting in OpenCode's database. This plugin turns that inaccessible history into usable context for the agent across sessions, projects, tool outputs, and reasoning traces, with zero setup."
+scope:
+  - global
+  - project
+homepage: https://github.com/rmk40/opencode-session-recall#readme


### PR DESCRIPTION
## Summary
- add Opencode Session Recall to the plugins list
- describe it as exposing stored session and project history already kept by OpenCode
- position it as direct access to hidden context rather than another memory layer

## Validation
- npm run validate
- npm run generate