### PR TITLE
docs: add opencode-model-scout to plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,15 @@
 </details>
 
 <details>
+  <summary><b>Opencode Model Scout</b> <img src="https://badgen.net/github/stars/rmk40/opencode-model-scout" height="14"/> - <i>Dynamically define local models with context limits and capabilities</i></summary>
+  <blockquote>
+    OpenAI-compatible local providers usually expose little more than model IDs. This plugin discovers available models and enriches them with real context limits, output limits, capability flags, and metadata from provider probes plus models.dev fallback, so OpenCode can use local and self-hosted models correctly without manual per-model config.
+    <br><br>
+    <a href="https://github.com/rmk40/opencode-model-scout">🔗 <b>View Repository</b></a>
+  </blockquote>
+</details>
+
+<details>
   <summary><b>Opencode Notify</b> <img src="https://badgen.net/github/stars/kdcokenny/opencode-notify" height="14"/> - <i>Native OS notifications</i></summary>
   <blockquote>
     Native OS notifications for OpenCode - know when tasks complete.

--- a/data/plugins/opencode-model-scout.yaml
+++ b/data/plugins/opencode-model-scout.yaml
@@ -1,0 +1,5 @@
+name: Opencode Model Scout
+repo: https://github.com/rmk40/opencode-model-scout
+tagline: Dynamically define local models with context limits and capabilities
+description: OpenAI-compatible local providers usually expose little more than model IDs. This plugin discovers available models and enriches them with real context limits, output limits, capability flags, and metadata from provider probes plus models.dev fallback, so OpenCode can use local and self-hosted models correctly without manual per-model config.
+homepage: https://github.com/rmk40/opencode-model-scout#readme


### PR DESCRIPTION
## Summary
- add Opencode Model Scout to the plugins list
- describe it as dynamically defining local models with context limits and capabilities
- position it around zero manual per-model config for OpenAI-compatible local providers

## Validation
- npm run validate
- npm run generate