### PR TITLE
docs: add opencode-models-discovery to plugins

### DIFF
--- a/data/plugins/opencode-models-discovery.yaml
+++ b/data/plugins/opencode-models-discovery.yaml
@@ -1,0 +1,4 @@
+name: Opencode Models Discovery
+repo: https://github.com/yuhp/opencode-models-discovery
+tagline: Configurable model discovery and filtering without long manual config
+description: OpenCode plugin for discovering models from OpenAI-compatible providers and API gateways, with provider and model filtering so users can avoid maintaining large configs or loading every model at once.


### PR DESCRIPTION
## Submission Type
- [x] Plugin
- [ ] Project
- [ ] Theme
- [ ] Agent
- [ ] Resource
## Details
**Name:** Opencode Models Discovery  
**Repository:** https://github.com/yuhp/opencode-models-discovery  
**Tagline:** Configurable model discovery and filtering without long manual config
## Why this belongs here
`opencode-models-discovery` is an OpenCode plugin that helps users working with OpenAI-compatible providers and API gateways avoid maintaining long manual model mappings in `opencode.json`.
It automatically discovers models from `/v1/models` and supports:
- provider-level filtering
- model-level filtering
- more selective loading for large gateway-backed model catalogs
This is especially useful for setups using gateways or providers like OneAPI, NewAPI, LiteLLM, Ollama, LM Studio, vLLM, and LocalAI.
## Checklist
- [x] Relevant to OpenCode
- [x] Repository is public and accessible
- [x] Actively maintained
- [x] Not a duplicate
- [x] YAML file in correct folder (`data/plugins/`)
- [x] Filename is kebab-case (e.g., `my-plugin.yaml`)