### PR TITLE
plugins: add opencode-cost-guard: Warn or stop your OpenCode session …

### DIFF
--- a/data/plugins/opencode-cost-guard.yaml
+++ b/data/plugins/opencode-cost-guard.yaml
@@ -1,0 +1,35 @@
+name: opencode-cost-guard
+repo: https://github.com/jjmartres/opencode-cost-guard
+tagline: Warn or stop your OpenCode session when it hits a spending limit
+description: |
+  opencode-cost-guard monitors your session cost in real time and fires a
+  warning message when you approach your budget, then a limit-reached alert
+  when you cross it.
+  OpenCode has no built-in per-session cost cap. This plugin fills that gap
+  with a single line of config.
+  **Features**
+  - Early warning at a configurable percentage of your budget (default 80%)
+  - Hard limit alert in warn or block mode when the threshold is crossed
+  - Each alert fires once per session — no spam
+  - Per-project config overrides the global one
+  - Zero dependencies, one line to install
+  **Install**
+  Add to `~/.config/opencode/opencode.json`:
+  ```json
+  { "plugins": ["opencode-cost-guard"] }
+  
+  **Configure**
+  Drop a cost-guard.config.json in ~/.config/opencode/:
+  ```json
+  {
+    "maxCostUsd": 20.0,
+    "warnAtPercent": 80,
+    "mode": "warn"
+  }
+  
+  Set mode to "block" to stop the session when the limit is reached.
+  Set COST_GUARD_DEBUG=1 to enable verbose per-event logging.
+  
+  Note: The limit is reactive — it fires after a response completes,
+  not before. One expensive response can push you over before the plugin
+  catches it.


### PR DESCRIPTION
…when it hits a spending limit

## Submission Type

- [x] Plugin
- [ ] Project
- [ ] Theme
- [ ] Agent
- [ ] Resource

## Details

**Name:** opencode-cost-guard
**Repository:** https://github.com/jjmartres/opencode-cost-guard
**Tagline:** Warn or stop your OpenCode session when it hits a spending limit
**Description:** 
```
  opencode-cost-guard monitors your session cost in real time and fires a
  warning message when you approach your budget, then a limit-reached alert
  when you cross it.
  OpenCode has no built-in per-session cost cap. This plugin fills that gap
  with a single line of config.
  **Features**
  - Early warning at a configurable percentage of your budget (default 80%)
  - Hard limit alert in warn or block mode when the threshold is crossed
  - Each alert fires once per session — no spam
  - Per-project config overrides the global one
  - Zero dependencies, one line to install
  **Install**
  Add to `~/.config/opencode/opencode.json`:
  ```json
  { "plugins": ["opencode-cost-guard"] }

  **Configure**
  Drop a cost-guard.config.json in ~/.config/opencode/:
  ```json
  {
    "maxCostUsd": 20.0,
    "warnAtPercent": 80,
    "mode": "warn"
  }

  Set mode to "block" to stop the session when the limit is reached.
  Set COST_GUARD_DEBUG=1 to enable verbose per-event logging.

  Note: The limit is reactive — it fires after a response completes,
  not before. One expensive response can push you over before the plugin
  catches it.
```
## Checklist

- [x] Relevant to OpenCode
- [x] Repository is public and accessible
- [x] Actively maintained
- [x] Not a duplicate
- [x] YAML file in correct folder (`data/{category}/`)
- [x] Filename is kebab-case (e.g., `my-plugin.yaml`)

## YAML Format

Create a file in `data/{category}/your-entry.yaml`:

```yaml
name: Your Entry Name
repo: https://github.com/owner/repo
tagline: Short punchy summary (shown in collapsed view)
description: Longer description explaining what it does.
```

See [contributing.md](contributing.md) for full instructions.
