### PR TITLE
docs: add AgentDeals to projects

### DIFF
--- a/data/projects/agentdeals.yaml
+++ b/data/projects/agentdeals.yaml
@@ -1,0 +1,4 @@
+name: AgentDeals
+repo: https://github.com/robhunter/agentdeals
+tagline: MCP server aggregating free tiers, credits, and referral codes across 1,500+ developer tools
+description: Remote MCP server that surfaces free tiers, credits, trials, and referral codes for developer infrastructure — Railway, Vercel, Fly, OpenAI, Anthropic, and 1,500+ other vendors. Exposes four tools (search_deals, plan_stack, compare_vendors, track_changes) so an agent can find the cheapest way to ship a given stack. Works with opencode via remote URL (https://agentdeals-production.up.railway.app/mcp). Also tracks pricing changes over time.


### PR DESCRIPTION
## What

Adds AgentDeals to `data/projects/` — a remote MCP server that surfaces free tiers, credits, and referral codes for developer infrastructure (Railway, Vercel, Fly, OpenAI, Anthropic, and 1,500+ other vendors).

## Why it's relevant to opencode

opencode already sees real traffic to AgentDeals — it's the #2 real-agent client by session volume on our server. Listing here makes the integration path easier to discover for opencode users who want agents to surface pricing, free tiers, and referral codes during stack-planning prompts.

## Entry requirements

- [x] **Relevant** — four MCP tools usable from opencode via remote URL
- [x] **Public** — github.com/robhunter/agentdeals
- [x] **Maintained** — active commits today (server at v0.3.1)
- [x] **Unique** — no existing AgentDeals entry
- [x] **Complete** — all required YAML fields

Live server: https://agentdeals-production.up.railway.app/mcp