### PR TITLE
docs: add opencode-plugin-codex-usage

### DIFF
--- a/data/plugins/opencode-plugin-codex-usage.yaml
+++ b/data/plugins/opencode-plugin-codex-usage.yaml
@@ -1,0 +1,4 @@
+name: opencode-plugin-codex-usage
+repo: https://github.com/anaskhan96/opencode-plugin-codex-usage
+tagline: Live Codex quota in the OpenCode sidebar
+description: OpenCode TUI plugin that shows live Codex usage buckets, remaining percentage, and reset times directly in the right sidebar.


### PR DESCRIPTION
## Submission Type

- [x] Plugin
- [ ] Project
- [ ] Theme
- [ ] Agent
- [ ] Resource

## Details

**Name:** opencode-plugin-codex-usage  
**Repository:** https://github.com/anaskhan96/opencode-plugin-codex-usage  
**Tagline:** Live Codex quota in the OpenCode sidebar

## Checklist

- [x] Relevant to OpenCode
- [x] Repository is public and accessible
- [x] Actively maintained
- [x] Not a duplicate
- [x] YAML file in correct folder (`data/plugins/`)
- [x] Filename is kebab-case (`opencode-plugin-codex-usage.yaml`)

## Summary

- adds a plugin entry for `opencode-plugin-codex-usage`
- describes it as a sidebar plugin for live Codex quota visibility inside OpenCode