### PR TITLE
docs: add opencode-profile-router to projects.

### DIFF
--- a/data/projects/opencode-profile-router.yaml
+++ b/data/projects/opencode-profile-router.yaml
@@ -1,0 +1,9 @@
+name: Opencode Profile Router
+repo: https://github.com/leolaurindo/opencode-profile-router
+tagline: Profile router for auth and selective config isolation
+description: Shell wrapper for OpenCode that selects named profiles by path and can isolate provider login state, config directories, and data roots selectively and independently per profile.
+tags:
+  - cli
+  - profiles
+  - auth
+  - routing


### PR DESCRIPTION
## Submission Type

- [ ] Plugin
- [x] Project
- [ ] Theme
- [ ] Agent
- [ ] Resource

## Details

**Name:**  Opencode Profile Router
**Repository:**  https://github.com/leolaurindo/opencode-profile-router
**Tagline:**: Profile router for auth and selective config isolation

## Checklist

- [x] Relevant to OpenCode
- [x] Repository is public and accessible
- [x] Actively maintained
- [x] Not a duplicate
- [x] YAML file in correct folder (`data/{category}/`)
- [x] Filename is kebab-case (e.g., `my-plugin.yaml`)

## YAML Format

File in `data/projects/opencode-profile-router.yaml`:

```yaml
name: Opencode Profile Router
repo: https://github.com/leolaurindo/opencode-profile-router
tagline: Profile router for auth and selective config isolation
description: Shell wrapper for OpenCode that selects named profiles by path and can isolate provider login state, config directories, and data roots selectively and independently per profile.
tags:
  - cli
  - profiles
  - auth
  - routing
```
