### PR TITLE
docs: add server-manager skill to agents

### DIFF
--- a/data/agents/server-manager.yaml
+++ b/data/agents/server-manager.yaml
@@ -1,5 +1,5 @@
 name: server-manager
-repo: https://github.com/workdocyeye/opencode-skills
+repo: https://github.com/workdocyeye/server-manager
 tagline: Start/stop/tail/grep local dev servers (Node/Python/Go/etc.) via PowerShell, with log tracking
 description: A skill for managing local development servers across multiple frameworks. Supports start, stop, list, health, tail, grep, and stop-all commands. Works with Node.js, Python, Go, .NET, Java, Rust, and PHP. Uses JSON for state persistence and per-project log files for error tracking.
 scope:
@@ -27,4 +27,4 @@ installation: |
   mkdir -p .opencode/skills/server-manager
   # Copy files there
   ```
-homepage: https://github.com/workdocyeye/opencode-skills/tree/main/server-manager
+homepage: https://github.com/workdocyeye/server-manager

--- a/data/agents/server-manager.yaml
+++ b/data/agents/server-manager.yaml
@@ -1,7 +1,7 @@
 name: server-manager
 repo: https://github.com/workdocyeye/server-manager
-tagline: Start/stop/tail/grep local dev servers (Node/Python/Go/etc.) via PowerShell, with log tracking
-description: A skill for managing local development servers across multiple frameworks. Supports start, stop, list, health, tail, grep, and stop-all commands. Works with Node.js, Python, Go, .NET, Java, Rust, and PHP. Uses JSON for state persistence and per-project log files for error tracking. In AI terminals like OpenCode, running `npm run dev` blocks the terminal — this skill solves that by running servers fully in the background without blocking your conversation.
+tagline: 在 AI 终端里运行 npm run dev 会一直占用终端，无法继续对话。本 skill 实现完全不阻塞的后台服务器管理。
+description: Start, track, and stop local dev servers in the background — without blocking your AI conversation. Supports Node.js, Python, Go, .NET, Java, Rust, PHP and any framework that runs a dev server. JSON state persistence, per-project log files, HTTP health checks, and log tail/grep for debugging.
 scope:
   - global
   - project

--- a/data/agents/server-manager.yaml
+++ b/data/agents/server-manager.yaml
@@ -1,0 +1,30 @@
+name: server-manager
+repo: https://github.com/workdocyeye/opencode-skills
+tagline: Start/stop/tail/grep local dev servers (Node/Python/Go/etc.) via PowerShell, with log tracking
+description: A skill for managing local development servers across multiple frameworks. Supports start, stop, list, health, tail, grep, and stop-all commands. Works with Node.js, Python, Go, .NET, Java, Rust, and PHP. Uses JSON for state persistence and per-project log files for error tracking.
+scope:
+  - global
+  - project
+tags:
+  - server
+  - devops
+  - management
+  - powershell
+  - windows
+installation: |
+  Global installation (recommended):
+  ```bash
+  # Create skill directory
+  mkdir -p ~/.config/opencode/skills/server-manager
+  # Copy all files
+  cp -r scripts/* ~/.config/opencode/skills/server-manager/
+  cp SKILL.md ~/.config/opencode/skills/server-manager/
+  ```
+
+  Project-level installation:
+  ```bash
+  # Create .opencode/skills/server-manager/
+  mkdir -p .opencode/skills/server-manager
+  # Copy files there
+  ```
+homepage: https://github.com/workdocyeye/opencode-skills/tree/main/server-manager

--- a/data/agents/server-manager.yaml
+++ b/data/agents/server-manager.yaml
@@ -12,19 +12,9 @@ tags:
   - powershell
   - windows
 installation: |
-  Global installation (recommended):
-  ```bash
-  # Create skill directory
-  mkdir -p ~/.config/opencode/skills/server-manager
-  # Copy all files
-  cp -r scripts/* ~/.config/opencode/skills/server-manager/
-  cp SKILL.md ~/.config/opencode/skills/server-manager/
-  ```
+  Global installation:
+  Download the entire `server-manager/` folder into `~/.config/opencode/skills/`
 
   Project-level installation:
-  ```bash
-  # Create .opencode/skills/server-manager/
-  mkdir -p .opencode/skills/server-manager
-  # Copy files there
-  ```
+  Download into `.opencode/skills/server-manager/` in your project root
 homepage: https://github.com/workdocyeye/server-manager

--- a/data/agents/server-manager.yaml
+++ b/data/agents/server-manager.yaml
@@ -1,7 +1,7 @@
 name: server-manager
 repo: https://github.com/workdocyeye/server-manager
 tagline: Start/stop/tail/grep local dev servers (Node/Python/Go/etc.) via PowerShell, with log tracking
-description: A skill for managing local development servers across multiple frameworks. Supports start, stop, list, health, tail, grep, and stop-all commands. Works with Node.js, Python, Go, .NET, Java, Rust, and PHP. Uses JSON for state persistence and per-project log files for error tracking.
+description: A skill for managing local development servers across multiple frameworks. Supports start, stop, list, health, tail, grep, and stop-all commands. Works with Node.js, Python, Go, .NET, Java, Rust, and PHP. Uses JSON for state persistence and per-project log files for error tracking. In AI terminals like OpenCode, running `npm run dev` blocks the terminal — this skill solves that by running servers fully in the background without blocking your conversation.
 scope:
   - global
   - project


### PR DESCRIPTION
## Summary
- Add `server-manager` skill entry under `data/agents/`
- Skill manages local dev servers (start/stop/tail/grep/health/list/stop-all) for Node.js, Python, Go, .NET, Java, Rust, PHP
- PowerShell-based, JSON state persistence, per-project log files
- Works on Windows (PowerShell)

## YAML entry
```yaml
name: server-manager
repo: https://github.com/workdocyeye/opencode-skills
tagline: Start/stop/tail/grep local dev servers (Node/Python/Go/etc.) via PowerShell, with log tracking
description: A skill for managing local development servers across multiple frameworks...
```

## Checklist
- [x] Relevant to OpenCode
- [x] Public repo accessible
- [x] All required fields included
- [x] Not a duplicate
