### PR TITLE
docs: add server-manager — non-blocking dev servers in AI terminals

### DIFF
--- a/data/agents/server-manager.yaml
+++ b/data/agents/server-manager.yaml
@@ -1,6 +1,6 @@
 name: server-manager
 repo: https://github.com/workdocyeye/server-manager
-tagline: 在 AI 终端里运行 npm run dev 会一直占用终端，无法继续对话。本 skill 实现完全不阻塞的后台服务器管理。
+tagline: Running npm run dev in an AI terminal blocks the session. This skill adds fully non-blocking background server management.
 description: Start, track, and stop local dev servers in the background — without blocking your AI conversation. Supports Node.js, Python, Go, .NET, Java, Rust, PHP and any framework that runs a dev server. JSON state persistence, per-project log files, HTTP health checks, and log tail/grep for debugging.
 scope:
   - global

--- a/data/agents/server-manager.yaml
+++ b/data/agents/server-manager.yaml
@@ -1,0 +1,18 @@
+name: server-manager
+repo: https://github.com/workdocyeye/server-manager
+tagline: 在 AI 终端里运行 npm run dev 会一直占用终端，无法继续对话。本 skill 实现完全不阻塞的后台服务器管理。
+description: Start, track, and stop local dev servers in the background — without blocking your AI conversation. Supports Node.js, Python, Go, .NET, Java, Rust, PHP and any framework that runs a dev server. JSON state persistence, per-project log files, HTTP health checks, and log tail/grep for debugging.
+scope:
+  - global
+  - project
+tags:
+  - server
+  - devops
+  - management
+  - powershell
+  - windows
+installation: |
+  Download the entire `server-manager/` folder into your skills directory:
+  - Global: `~/.config/opencode/skills/server-manager/`
+  - Project: `.opencode/skills/server-manager/` in your project root
+homepage: https://github.com/workdocyeye/server-manager


### PR DESCRIPTION
## Summary
- Add `server-manager` skill to agents list
- Tagline: 在 AI 终端里运行 npm run dev 会一直占用终端，无法继续对话。本 skill 实现完全不阻塞的后台服务器管理。
- Supports Node.js, Python, Go, .NET, Java, Rust, PHP and any dev server

## Checklist
- [x] Relevant to OpenCode
- [x] Public repo accessible
- [x] All required fields included
- [x] Not a duplicate
