### PR TITLE
docs: add server-manager — non-blocking dev servers in AI terminals

### DIFF
--- a/data/agents/server-manager.yaml
+++ b/data/agents/server-manager.yaml
@@ -1,0 +1,18 @@
+name: server-manager
+repo: https://github.com/workdocyeye/server-manager
+tagline: Running npm run dev in an AI terminal blocks the session. This skill adds fully non-blocking background server management.
+description: Start, track, and stop local dev servers in the background — without blocking your AI conversation. Supports Node.js, Python, Go, .NET, Java, Rust, PHP and any framework that runs a dev server. JSON state persistence, per-project log files, HTTP health checks, and log tail/grep for debugging.
+scope:
+  - global
+  - project
+tags:
+  - server
+  - devops
+  - management
+  - powershell
+  - windows
+installation: |
+  Download the entire `server-manager/` folder into your skills directory:
+  - Global: `~/.config/opencode/skills/server-manager/`
+  - Project: `.opencode/skills/server-manager/` in your project root
+homepage: https://github.com/workdocyeye/server-manager

--- a/data/agents/server-manager.yaml
+++ b/data/agents/server-manager.yaml
@@ -12,7 +12,8 @@ tags:
   - powershell
   - windows
 installation: |
-  Download the entire `server-manager/` folder into your skills directory:
-  - Global: `~/.config/opencode/skills/server-manager/`
-  - Project: `.opencode/skills/server-manager/` in your project root
+  Download the entire `server-manager/` folder into your AI coding tool's skills directory:
+  - OpenCode: `~/.config/opencode/skills/server-manager/`
+  - Claude Code: `~/.claude/skills/server-manager/`
+  - Project-level: `.opencode/skills/` or `.claude/skills/` in your project root
 homepage: https://github.com/workdocyeye/server-manager


### PR DESCRIPTION
## Summary
- Add server-manager skill to agents list
- Tagline: Running npm run dev in an AI terminal blocks the session. This skill adds fully non-blocking background server management.
- Supports Node.js, Python, Go, .NET, Java, Rust, PHP and any dev server

## Checklist
- [x] Relevant to OpenCode
- [x] Public repo accessible
- [x] All required fields included
- [x] Not a duplicate