### PR TITLE
Add opencode-provider-alias plugin

### DIFF
--- a/data/plugins/opencode-provider-alias.yaml
+++ b/data/plugins/opencode-provider-alias.yaml
@@ -1,0 +1,4 @@
+name: OpenCode Provider Alias
+repo: https://github.com/baranwang/opencode-provider-alias
+tagline: Alias and curate OpenCode providers with model metadata from models.dev.
+description: Lets users define local OpenCode provider and model aliases hydrated from existing models.dev metadata.


### PR DESCRIPTION
## Summary
- Adds a public MIT-licensed OpenCode plugin catalog entry for opencode-provider-alias.
- Notes that the plugin lets users define local provider and model aliases hydrated from models.dev metadata.
- Performed YAML validation and reviewed the single-file diff.