### PR TITLE
docs: add prompt-to-asset (projects) and unslop (plugins)

### DIFF
--- a/data/plugins/unslop.yaml
+++ b/data/plugins/unslop.yaml
@@ -1,0 +1,4 @@
+name: unslop
+repo: https://github.com/MohamedAbdallah-14/unslop
+tagline: Strip AI writing patterns before publishing
+description: Claude Code plugin and CLI that removes sycophantic openers, stock vocabulary, hedging stacks, and em-dash overuse from AI-generated output. Engineers sentence burstiness. Code, URLs, and technical terms pass through unchanged. Pipe mode for scripting.

--- a/data/projects/prompt-to-asset.yaml
+++ b/data/projects/prompt-to-asset.yaml
@@ -1,0 +1,4 @@
+name: Prompt to Asset
+repo: https://github.com/MohamedAbdallah-14/prompt-to-asset
+tagline: Generate visual assets across 30+ image models via MCP
+description: MCP server that generates production-ready visual assets (app icons, favicons, OG images, logos, wordmarks) by routing prompts across 30+ image generation models. Three execution modes: inline SVG, external prompt, and full API generation. Zero API key required for first run via Pollinations and Stable Horde free tiers.


### PR DESCRIPTION
## Add prompt-to-asset (projects) and unslop (plugins)

### data/projects/prompt-to-asset.yaml — Prompt to Asset

MCP server that generates production-ready visual assets (app icons, favicons, OG images, logos, wordmarks) by routing prompts across 30+ image generation models. Three execution modes: inline SVG, external prompt, and full API generation. Zero API key required for first run via Pollinations and Stable Horde free tiers.

https://github.com/MohamedAbdallah-14/prompt-to-asset

### data/plugins/unslop.yaml — unslop

Claude Code plugin and CLI that removes sycophantic openers, stock vocabulary, hedging stacks, and em-dash overuse from AI-generated output before publishing. Engineers sentence burstiness. Code, URLs, and technical terms pass through unchanged.

https://github.com/MohamedAbdallah-14/unslop

Both are MIT licensed.