### PR TITLE
Add Agent Sessions

### DIFF
--- a/data/projects/agent-sessions.yaml
+++ b/data/projects/agent-sessions.yaml
@@ -1,0 +1,4 @@
+name: Agent Sessions
+repo: https://github.com/jazzyalex/agent-sessions
+tagline: macOS session browser and live cockpit
+description: Native macOS app for browsing, searching, and resuming local OpenCode sessions alongside Codex CLI, Claude Code, Gemini CLI, and other coding agents, with Agent Cockpit live monitoring for iTerm2 workflows.


### PR DESCRIPTION
Adds Agent Sessions as an OpenCode-related project.

Why it fits:
- Supports browsing, searching, and resuming local OpenCode sessions.
- Covers adjacent coding agents such as Codex CLI, Claude Code, and Gemini CLI.
- Includes Agent Cockpit for live iTerm2 monitoring/orchestration of local agent workflows.
- Follows the repo data format by adding a YAML entry under data/projects/.