### PR TITLE
docs: add opencode-adaptive-thinking to plugins

### DIFF
--- a/data/plugins/opencode-adaptive-thinking.yaml
+++ b/data/plugins/opencode-adaptive-thinking.yaml
@@ -1,0 +1,4 @@
+name: OpenCode Adaptive Thinking
+repo: https://github.com/ian-pascoe/opencode-adaptive-thinking
+tagline: Adaptive reasoning-effort control
+description: OpenCode plugin that lets agents actively adjust model reasoning effort during a session, with configurable system guidance and a tool for switching between valid reasoning-effort variants.


### PR DESCRIPTION
## Summary
- Add OpenCode Adaptive Thinking to the plugin list.
- Include the repository, tagline, and description in the expected YAML contribution format.

## Validation
- npm run validate