### PR TITLE
docs: add SuperBased to plugins

### DIFF
--- a/data/plugins/superbased.yaml
+++ b/data/plugins/superbased.yaml
@@ -1,0 +1,60 @@
+name: SuperBased
+repo: https://github.com/marmutapp/superbased-opencode-plugin
+tagline: Screen capture, AI vision, OCR, and full GUI automation — 72 MCP tools
+description: |
+  SuperBased connects OpenCode to your screen AND your desktop via 72 MCP tools.
+  Capture screenshots (fullscreen / window / region), run AI vision and local
+  OCR, record sessions for visual regression testing, transcribe voice via
+  microphone, AND drive the full desktop with GUI automation primitives — click,
+  type, hotkey, scroll, drag, hover, form-fill, sequence, dialog handling, tab
+  management, virtual desktops — with humanization v2 (sin-shaped velocity
+  envelope, gaussian click-target jitter, gamma-distributed pre-click dwell,
+  per-process cross-session salt) and proactive CAPTCHA-solving guidance for
+  reCAPTCHA / Cloudflare Turnstile / drag puzzles / rotation puzzles. Hybrid
+  plugin: npm `superbased-opencode-plugin` ships TypeScript lifecycle hooks
+  (pre-flight safety checks, post-flight telemetry, audit-log surfacing); the
+  72 tools live in the SuperBased MCP server (`superbased mcp`) configured
+  separately in `opencode.json`. Skills, commands, and agents bundled as
+  reference markdown.
+scope:
+  - global
+tags:
+  - mcp
+  - screenshot
+  - screen-capture
+  - ocr
+  - ai-vision
+  - screen-recording
+  - visual-testing
+  - gui-automation
+  - click-automation
+  - form-fill
+  - captcha
+  - humanization
+  - dictation
+  - voice
+homepage: https://superbased.app
+installation: |
+  ```bash
+  npm install -g superbased-opencode-plugin superbased
+  ```
+
+  Then add to `opencode.json`:
+
+  ```json
+  {
+    "$schema": "https://opencode.ai/config.json",
+    "plugin": ["superbased-opencode-plugin"],
+    "mcp": {
+      "superbased": {
+        "type": "local",
+        "command": ["superbased", "mcp"],
+        "enabled": true
+      }
+    }
+  }
+  ```
+
+  Optional: install the SuperBased desktop app from
+  [superbased.app](https://superbased.app) for a GUI to browse captures
+  and configure providers — the headless CLI works standalone.


### PR DESCRIPTION
Adds SuperBased — eyes AND hands for OpenCode via 72 MCP tools.

**What it does:** Capture screenshots, run AI vision and local OCR, record sessions for visual regression testing, transcribe voice via microphone, AND drive the full desktop with GUI automation primitives (click, type, hotkey, scroll, drag, hover, form-fill, sequence) — with humanization v2 and proactive CAPTCHA-solving guidance.

**How it ships:** Hybrid plugin —
- npm `superbased-opencode-plugin` ships TypeScript lifecycle hooks (pre-flight safety checks, post-flight telemetry on expensive calls > 5s, audit-log surfacing once per session).
- The 72 MCP tools live in the SuperBased MCP server (`superbased mcp`), configured separately in `opencode.json` under `mcp.superbased`.
- Skills, commands, and agents bundled as reference markdown for OpenCode users to copy into context.

**Repository:** https://github.com/marmutapp/superbased-opencode-plugin
**Homepage:** https://superbased.app
**npm:** https://www.npmjs.com/package/superbased-opencode-plugin (v2.0.2 live)

Entry passes the requirements checklist:
- ✅ Relevant — directly related to OpenCode (registers as a plugin via `plugin` array, plus separate MCP server config for the 72 tools).
- ✅ Public — both the GitHub repo and the npm package are public.
- ✅ Maintained — v2.0.2 published 2026-04-26 with 42 new GUI automation tools shipped this release.
- ✅ Unique — no existing SuperBased entry in the data/ tree.
- ✅ Complete — all required schema fields (name / repo / tagline / description) plus optional scope / tags / homepage / installation.

Co-published to Claude Code, OpenAI Codex, Cursor, GitHub Copilot CLI, OpenClaw plugin marketplaces — see https://superbased.app/setup for the full list.