### PR TITLE
docs: add opencode-power-pack to plugins

### DIFF
--- a/data/plugins/opencode-power-pack.yaml
+++ b/data/plugins/opencode-power-pack.yaml
@@ -1,0 +1,15 @@
+name: opencode-power-pack
+repo: https://github.com/waybarrios/opencode-power-pack
+tagline: Eleven Claude Code skills (code-review, security-review, feature-dev, etc.) ported to OpenCode
+description: |
+  Bundles eleven of Anthropic's official Claude Code skills as a single OpenCode plugin: code-review, security-review, feature-dev, frontend-design, mcp-builder, skill-creator, agents-md-improver, agents-md-revise, plus the three feature-dev sub-agents (code-explorer, code-architect, code-reviewer). Each skill is also exposed as a slash command (`/code-review`, `/security-review`, etc.). The plugin loader pattern (registering skills via `config.skills.paths.push()`) is adapted from obra/superpowers. Per-skill upstream attribution to Anthropic is in the README; the repo's contribution is the porting and packaging of Claude-Code-only commands and agents into OpenCode-native SKILL.md format.
+scope:
+  - global
+tags:
+  - claude-code
+  - skills
+  - code-review
+  - security-review
+  - feature-dev
+  - frontend-design
+  - mcp


### PR DESCRIPTION
## Summary

Adding [opencode-power-pack](https://github.com/waybarrios/opencode-power-pack) — an OpenCode plugin that bundles eleven of Anthropic's official Claude Code skills (code-review, security-review, feature-dev, frontend-design, mcp-builder, skill-creator, AGENTS.md / CLAUDE.md auditors, and the three feature-dev sub-agents) as a single OpenCode plugin. Each skill is also exposed as a slash command.

The plugin loader pattern is adapted from `obra/superpowers`. Per-skill upstream attribution to Anthropic is in the README — the repo's contribution is the porting and packaging of Claude-Code-only commands and agents into OpenCode-native SKILL.md format.

## Checklist

- [x] **Relevant** — direct OpenCode plugin
- [x] **Public** — MIT-licensed, public repo
- [x] **Maintained** — v0.1.0 released today, active development
- [x] **Unique** — not duplicating an existing entry
- [x] **Complete** — YAML has `name`, `repo`, `tagline` (94 chars / 120 max), `description`, `scope`, `tags`
