### PR TITLE
docs: add Gaeta to projects

### DIFF
--- a/data/projects/gaeta.yaml
+++ b/data/projects/gaeta.yaml
@@ -1,0 +1,4 @@
+name: Gaeta
+repo: https://github.com/aemonge/gaeta
+tagline: OpenCode-safe wrapper with phase-driven workflow control
+description: Guided Assistant Engineered Taskflow Agent — an OpenCode-safe wrapper using bubblewrap (with optional Landlock defense-in-depth) that enforces a phase-driven, methodology-disciplined workflow around OpenCode without forking its internals.


### PR DESCRIPTION
## Summary

Adds [Gaeta](https://github.com/aemonge/gaeta) to `data/projects/`.

Gaeta ("Guided Assistant Engineered Taskflow Agent") is an OpenCode-safe
wrapper that uses bubblewrap (with optional Landlock defense-in-depth) and
enforces a phase-driven, methodology-disciplined workflow around OpenCode
without forking its internals. It fits alongside other wrappers/integrations
already listed under `projects/` (Cupcake, OpenChamber, oc-manager, etc.).

## Entry checklist

- [x] **Relevant** — wraps OpenCode directly
- [x] **Public** — https://github.com/aemonge/gaeta
- [x] **Maintained** — recent commits on `main`
- [x] **Unique** — not already in the list
- [x] **Complete** — all required schema fields present
- [x] `npm run validate` passes locally (118 files, all green)

## Files

- `data/projects/gaeta.yaml` (new)