### PR TITLE
docs: add opencode-litellm to plugins

### DIFF
--- a/data/plugins/opencode-litellm.yaml
+++ b/data/plugins/opencode-litellm.yaml
@@ -1,0 +1,19 @@
+name: Opencode LiteLLM
+repo: https://github.com/yuseferi/opencode-litellm
+tagline: Auto-discover models from a LiteLLM proxy
+description: |
+  Drop-in LiteLLM provider for OpenCode with zero configuration. Auto-detects a running
+  LiteLLM proxy on common ports (4000, 8000, 8080), pulls every model from /v1/models,
+  and registers them in OpenCode automatically — no model lists to hand-maintain. Smart
+  name formatting, modality categorization (chat/embedding/image/audio), provider
+  extraction, optional API-key auth, and a 5-second timeout so a slow proxy never blocks
+  startup.
+scope:
+  - global
+  - project
+tags:
+  - litellm
+  - provider
+  - openai-compatible
+  - llm-proxy
+  - model-discovery


### PR DESCRIPTION
## Summary

Adds [`opencode-litellm`](https://github.com/yuseferi/opencode-litellm) — a new OpenCode plugin that auto-discovers models from a [LiteLLM](https://github.com/BerriAI/litellm) proxy, similar to how [`opencode-lmstudio`](https://github.com/agustif/opencode-lmstudio) works for LM Studio.

## What it does

- Auto-detects a running LiteLLM proxy on common ports (`4000`, `8000`, `8080`)
- Pulls every model from `/v1/models` and registers them as OpenCode models automatically
- Smart name formatting (e.g. `anthropic/claude-3-5-sonnet` → `Claude 3 5 Sonnet`)
- Modality categorization — chat / embedding / image / audio
- Provider extraction (`litellm_provider` → `organizationOwner`)
- Optional API-key auth via `LITELLM_API_KEY` env var or `provider.litellm.options.apiKey`
- 5-second discovery timeout so a slow proxy never blocks startup

## Entry checklist

- [x] **Relevant** — directly extends OpenCode with a new provider
- [x] **Public** — repo is public at https://github.com/yuseferi/opencode-litellm
- [x] **Maintained** — created today, v0.1.1 just shipped
- [x] **Unique** — no existing entry for LiteLLM in `data/plugins/`
- [x] **Complete** — all required fields present (`name`, `repo`, `tagline`, `description`); also includes optional `scope` and `tags`
- [x] **Validates** — `npm run validate` passes locally