### PR TITLE
docs: add CrewBee to plugins

### DIFF
--- a/data/plugins/crewbee.yaml
+++ b/data/plugins/crewbee.yaml
@@ -1,0 +1,4 @@
+name: CrewBee
+repo: https://github.com/CrewBeeLab/CrewBee
+tagline: Task-specific Agent Teams for OpenCode
+description: CrewBee is an independent Agent Team framework for OpenCode. It lets users define reusable task/project-specific Agent Teams, project them into OpenCode agents, and switch between single-agent execution and multi-agent collaboration based on task complexity. It also includes built-in Team templates such as a Coding Team with review flow and completion criteria.


### PR DESCRIPTION
## What

Adds CrewBee to the plugins list.

## Why

CrewBee is an independent Agent Team framework for OpenCode. It integrates through the OpenCode plugin model and helps users define task/project-specific Agent Teams, project them into OpenCode agents, and use single-agent or multi-agent workflows based on task complexity.

## Checklist

- Public repository
- Directly related to OpenCode
- YAML entry added under `data/plugins/`
- Required fields included