### PR TITLE
docs: add BRHP plugin

### DIFF
--- a/data/plugins/brhp.yaml
+++ b/data/plugins/brhp.yaml
@@ -1,0 +1,4 @@
+name: BRHP
+repo: https://github.com/ZanzyTHEbar/brhp
+tagline: Persistent planning state
+description: Structured, persistent planning for OpenCode with local session state, /brhp commands, bounded planner history, and a TUI sidebar.


### PR DESCRIPTION
## Summary
- Adds BRHP to the plugins data set.
- BRHP provides structured, persistent planning for OpenCode with local session state, `/brhp` commands, bounded planner history, and a TUI sidebar.

## Validation
- `npm run validate`