### PR TITLE
Add supamem to projects (dual-memory MCP CLI)

### DIFF
--- a/data/projects/supamem.yaml
+++ b/data/projects/supamem.yaml
@@ -1,0 +1,4 @@
+name: supamem
+repo: https://github.com/dzmitrys-dev/supamem/
+tagline: Project-agnostic dual-memory MCP CLI for OpenCode
+description: Adds semantic memory (Qdrant tuned hybrid retrieval — RRF fusion of dense MiniLM + sparse BM25) and structural memory hooks to OpenCode via MCP. Ships an installer that wires `qdrant-find` / `qdrant-store` tools and a snapshot hook into your project's OpenCode config. Python 3.12+, MIT, on PyPI as `supamem`.


### PR DESCRIPTION
Adds **supamem** as a YAML data file at `data/projects/supamem.yaml` under the 🛠 PROJECTS category.

**About supamem:**

- Project-agnostic dual-memory layer for OpenCode (also Claude Code and Cursor)
- Semantic memory: Qdrant tuned hybrid retrieval — RRF fusion of dense MiniLM + sparse BM25
- Structural memory: project snapshot hooks
- Ships an installer (`supamem install --client opencode`) that wires `qdrant-find` / `qdrant-store` tools and a snapshot hook into your OpenCode config
- Python 3.12+, MIT, on PyPI as `supamem`

**Conformance:**

- Required YAML fields: `name`, `repo`, `tagline` (49 chars, ≤120), `description` ✓
- Validates via `python -c "import yaml; yaml.safe_load(open('data/projects/supamem.yaml'))"` ✓
- Single project per PR (no bundling)
- Repo is public, MIT, actively maintained