### PR TITLE
docs: add hiai-opencode to plugins

### DIFF
--- a/data/plugins/hiai-opencode.yaml
+++ b/data/plugins/hiai-opencode.yaml
@@ -1,0 +1,4 @@
+name: hiai-opencode
+repo: https://github.com/HiAi-gg/hiai-opencode
+tagline: Canonical 12-agent model with bundled skills, MCP, LSP, and ralph-loop
+description: Unified plugin shipping 10 visible agents (Bob, Coder, Strategist, Critic, Guard, Researcher, Designer, Manager, Brainstormer, Vision) plus hidden Sub and Agent Skills. Bundles MCP wiring (playwright, stitch, sequential-thinking, firecrawl, rag, mempalace, context7, websearch, grep_app), LSP, skill materialization, and a multi-layer continuation system (todo enforcer, ralph-loop, ULTRAWORK auto-start) in one install.


### PR DESCRIPTION
 ## Submission Type

  - [x] Plugin
  - [ ] Project
  - [ ] Theme
  - [ ] Agent
  - [ ] Resource

  ## Details

  **Name:** hiai-opencode
  **Repository:** https://github.com/HiAi-gg/hiai-opencode
  **Tagline:** Canonical 12-agent model with bundled skills, MCP, LSP, and ralph-loop

  ## Checklist

  - [x] Relevant to OpenCode
  - [x] Repository is public and accessible
  - [x] Actively maintained
  - [x] Not a duplicate
  - [x] YAML file in correct folder (`data/plugins/`)
  - [x] Filename is kebab-case (`hiai-opencode.yaml`)

  ## YAML Format

  File: `data/plugins/hiai-opencode.yaml`

  ```yaml
  name: hiai-opencode
  repo: https://github.com/HiAi-gg/hiai-opencode
  tagline: Canonical 12-agent model with bundled skills, MCP, LSP, and ralph-loop
  description: Unified plugin shipping 10 visible agents (Bob, Coder, Strategist, Critic, Guard, Researcher, Designer,
  Manager, Brainstormer, Vision) plus hidden Sub and Agent Skills. Bundles MCP wiring (playwright, stitch,
  sequential-thinking, firecrawl, rag, mempalace, context7, websearch, grep_app), LSP, skill materialization, and a
  multi-layer continuation system in one install.