### PR TITLE
docs: add opencode-swarm to plugins

### DIFF
--- a/data/plugins/opencode-swarm.yaml
+++ b/data/plugins/opencode-swarm.yaml
@@ -1,0 +1,4 @@
+name: OpenCode Swarm
+repo: https://github.com/zaxbysauce/opencode-swarm
+tagline: Verification-gated swarm with architect, review, test, and security agents
+description: Verification-gated OpenCode swarm with architect planning, independent review, test engineering, security checks, and resumable evidence.


### PR DESCRIPTION
## Summary

Adds `data/plugins/opencode-swarm.yaml` for [zaxbysauce/opencode-swarm](https://github.com/zaxbysauce/opencode-swarm) — a verification-gated OpenCode swarm with architect planning, independent review, test engineering, security checks, and resumable evidence.

This is distinct from the existing `Swarm Plugin` entry (joelhooks/opencode-swarm-plugin), which is left untouched.

## Checks

- [x] `npm install` — succeeded
- [x] `npm run validate` — all 118 files passed validation
- [x] Filename uses kebab-case (`opencode-swarm.yaml`)
- [x] Required fields present: name, repo, tagline, description
- [x] Public, maintained repository