### PR TITLE
docs: add agenttrace

### DIFF
--- a/data/projects/agenttrace.yaml
+++ b/data/projects/agenttrace.yaml
@@ -1,0 +1,4 @@
+name: agenttrace
+repo: https://github.com/luoyuctl/agenttrace
+tagline: Local TUI for OpenCode session cost, health, and trace reports
+description: Local-first Bubble Tea TUI and report CLI for inspecting OpenCode and other AI coding-agent logs with cost, tokens, latency, tool failures, anomalies, health gates, diffs, and reports.


### PR DESCRIPTION
Adds agenttrace as a project for inspecting OpenCode-style and other AI coding agent session traces from the terminal.

It fits the Projects category because it is a local-first CLI/TUI utility for reviewing session cost, failures, latency, anomalies, health gates, and diffs.

Validation:
- `npm install`
- `npm run validate`
- `git diff --check`
