### PR TITLE
docs: add SwarmClaw to projects

### DIFF
--- a/data/projects/swarmclaw.yaml
+++ b/data/projects/swarmclaw.yaml
@@ -1,0 +1,4 @@
+name: SwarmClaw
+repo: https://github.com/swarmclawai/swarmclaw
+tagline: Self-hosted multi-agent runtime with first-class OpenCode delegation
+description: Self-hosted runtime for autonomous AI agents with heartbeats, schedules, delegation, memory, runtime skills, and reviewed conversation-to-skill learning. Orchestrates OpenCode alongside Claude Code, Codex, Gemini CLI, Copilot CLI, Cursor Agent, Goose, Qwen Code, Droid, and 20+ LLM providers. Ships as an Electron desktop app, CLI, and Docker image. MCP-native (server and client). MIT, TypeScript.


### PR DESCRIPTION
Adds [SwarmClaw](https://github.com/swarmclawai/swarmclaw) under Projects.

SwarmClaw is a self-hosted runtime for autonomous AI agents with heartbeats, schedules, delegation, memory, runtime skills, and reviewed conversation-to-skill learning. It orchestrates OpenCode as a first-class delegated coding agent alongside Claude Code, Codex, Gemini CLI, Copilot CLI, Cursor Agent, Goose, Qwen Code, Droid, and 20+ LLM providers. Ships as an Electron desktop app, CLI, and Docker image. MCP-native (server and client). MIT, TypeScript.

- Repo: https://github.com/swarmclawai/swarmclaw
- License: MIT

### Entry Requirements

- [x] Relevant: ships native OpenCode CLI delegation alongside other coding agents.
- [x] Public: https://github.com/swarmclawai/swarmclaw
- [x] Maintained: commits within the last 6 months (active development).
- [x] Unique: not a duplicate.
- [x] Complete: name, repo, tagline, description fields included in `data/projects/swarmclaw.yaml`.