### PR TITLE
docs: add flowdeck to plugins

### DIFF
--- a/data/plugins/flowdeck.yaml
+++ b/data/plugins/flowdeck.yaml
@@ -1,0 +1,56 @@
+name: FlowDeck
+repo: https://github.com/DVNghiem/FlowDeck
+tagline: AI-powered multi-agent workflow orchestration with built-in safety intelligence
+description: |
+  FlowDeck adds a structured, multi-agent development workflow to OpenCode. It coordinates 25 specialist agents through a four-phase cycle — discuss, plan, execute, review — with persistent state that survives session restarts.
+
+  Key features:
+  - 25 specialist agents (architect, planner, coder, reviewer, tester, debugger, risk-analyst, policy-enforcer, and more)
+  - 24 reusable workflow skills (TDD, security scan, deploy check, code review, and more)
+  - 17 workflow commands for all project operations
+  - 15 pre-built orchestration flows including Spec-Driven Development (SDD)
+  - Persistent state via `.planning/STATE.md` — resume exactly where you left off
+  - Wave-based parallel execution for independent tasks
+  - AI Safety layer: patch trust scoring, edit gates, phase gating, arch constraint enforcement, failure replay, and regression prediction
+  - Deep System Hooks: context monitoring, session idle summaries, shell environment injection
+  - Built-in MCPs: Context7 (docs), Exa (web search), Grep.app (code search)
+  - Ensemble Reasoning via `/fd-council` for synthesized consensus from multiple agents
+  - Persistent Memory with SQLite for tool executions and session summaries
+scope:
+  - global
+tags:
+  - workflow
+  - orchestration
+  - multi-agent
+  - planning
+  - security
+  - TDD
+  - skills
+  - commands
+min_version: "1.0.0"
+homepage: https://github.com/DVNghiem/FlowDeck#readme
+installation: |
+  ### Method 1: curl (recommended)
+  ```bash
+  curl -fsSL https://raw.githubusercontent.com/DVNghiem/flowdeck/main/install.sh | bash
+  ```
+
+  ### Method 2: npx
+  ```bash
+  npx @dv.nghiem/flowdeck install
+  ```
+
+  After installation, verify with:
+  ```bash
+  ls ~/.config/opencode/agent/ | grep -c "\.md"  # Should show 23+
+  ls ~/.config/opencode/skills/                   # Should show 24+
+  cat ~/.config/opencode/opencode.json | grep flowdeck  # Should show @dv.nghiem/flowdeck
+  ```
+
+  Core workflow commands:
+  - `/fd-new-project` — Bootstrap a new project with PROJECT.md, ROADMAP.md, STATE.md
+  - `/fd-discuss` — Pre-planning structured Q&A to capture decisions
+  - `/fd-plan` — Generate a wave-structured execution plan from decisions
+  - `/fd-new-feature` — Implement a feature with TDD discipline and parallel agents
+  - `/fd-checkpoint` — Save a session checkpoint to STATE.md
+  - `/fd-resume` — Reload STATE.md and PLAN.md to continue interrupted session

--- a/data/plugins/flowdeck.yaml
+++ b/data/plugins/flowdeck.yaml
@@ -40,13 +40,6 @@ installation: |
   npx @dv.nghiem/flowdeck install
   ```
 
-  After installation, verify with:
-  ```bash
-  ls ~/.config/opencode/agent/ | grep -c "\.md"  # Should show 23+
-  ls ~/.config/opencode/skills/                   # Should show 24+
-  cat ~/.config/opencode/opencode.json | grep flowdeck  # Should show @dv.nghiem/flowdeck
-  ```
-
   Core workflow commands:
   - `/fd-new-project` — Bootstrap a new project with PROJECT.md, ROADMAP.md, STATE.md
   - `/fd-discuss` — Pre-planning structured Q&A to capture decisions


### PR DESCRIPTION
## Submission Type

- [x] Plugin
- [ ] Project
- [ ] Theme
- [ ] Agent
- [ ] Resource

## Details

**Name:** FlowDeck
**Repository:** https://github.com/DVNghiem/FlowDeck
**Tagline:** AI-powered multi-agent workflow orchestration with built-in safety intelligence for OpenCode

## Checklist

- [x] Relevant to OpenCode
- [x] Repository is public and accessible
- [x] Actively maintained
- [x] Not a duplicate
- [x] YAML file in correct folder (`data/{category}/`)
- [x] Filename is kebab-case (e.g., `my-plugin.yaml`)

## YAML Format

Create a file in `data/{category}/your-entry.yaml`:

```yaml
name: FlowDeck
repo: https://github.com/DVNghiem/FlowDeck
tagline: AI-powered multi-agent workflow orchestration with built-in safety intelligence
description: |
  FlowDeck adds a structured, multi-agent development workflow to OpenCode. It coordinates 25 specialist agents through a four-phase cycle — discuss, plan, execute, review — with persistent state that survives session restarts.

  Key features:
  - 25 specialist agents (architect, planner, coder, reviewer, tester, debugger, risk-analyst, policy-enforcer, and more)
  - 24 reusable workflow skills (TDD, security scan, deploy check, code review, and more)
  - 17 workflow commands for all project operations
  - 15 pre-built orchestration flows including Spec-Driven Development (SDD)
  - Persistent state via `.planning/STATE.md` — resume exactly where you left off
  - Wave-based parallel execution for independent tasks
  - AI Safety layer: patch trust scoring, edit gates, phase gating, arch constraint enforcement, failure replay, and regression prediction
  - Deep System Hooks: context monitoring, session idle summaries, shell environment injection
  - Built-in MCPs: Context7 (docs), Exa (web search), Grep.app (code search)
  - Ensemble Reasoning via `/fd-council` for synthesized consensus from multiple agents
  - Persistent Memory with SQLite for tool executions and session summaries
```

See [contributing.md](contributing.md) for full instructions.
