### PR TITLE
Add OpenCode Chromium Browser Plugin

### DIFF
--- a/data/plugins/opencode-chromium-browser-plugin.yaml
+++ b/data/plugins/opencode-chromium-browser-plugin.yaml
@@ -1,0 +1,13 @@
+name: OpenCode Chromium Browser Plugin
+repo: https://github.com/DJOCKER-FACE/opencode-chromium-browser-plugin
+tagline: Browser automation for Chromium browsers with a readable extension and native host
+description: OpenCode browser automation for Chromium-based browsers using a readable Manifest V3 extension, Node.js native messaging host, and OpenCode-native tools. Supports Chrome, Edge, Brave, Chromium, screenshots, CDP commands, DOM actions, downloads, console/network inspection, and controlled tab sessions.
+scope:
+  - project
+tags:
+  - browser
+  - chromium
+  - automation
+  - native-messaging
+  - cdp
+homepage: https://github.com/DJOCKER-FACE/opencode-chromium-browser-plugin


### PR DESCRIPTION
## Summary
- Adds OpenCode Chromium Browser Plugin to the plugins list.
- Provides Chromium-family browser automation through a readable MV3 extension, Node.js native messaging host, and OpenCode-native tools.

## Links
- Repository: https://github.com/DJOCKER-FACE/opencode-chromium-browser-plugin
- Demo / announcement: https://x.com/ABadissy/status/2052852726736789586

## Checklist
- Public repository
- Directly related to OpenCode
- MIT licensed
- Recently maintained
- YAML validated with `npm run validate -- data/plugins/opencode-chromium-browser-plugin.yaml`