### PR TITLE
docs: add Dodo Payments to plugins

### DIFF
--- a/data/plugins/dodo-payments.yaml
+++ b/data/plugins/dodo-payments.yaml
@@ -1,0 +1,4 @@
+name: Dodo Payments
+repo: https://github.com/dodopayments/dodo-agent-plugin
+tagline: Payments, subscriptions, webhooks, and billing for OpenCode agents
+description: Official Dodo Payments plugin for OpenCode (also Claude Code, Codex, Cursor). Bundles eight integration skills (checkout, subscriptions, webhooks, usage-based billing, credits, license keys, BillingSDK, best practices) plus two MCP servers — a live API server with browser OAuth and a documentation search server. Distributed via npm as @dodopayments/opencode-plugin.


### PR DESCRIPTION
Adds the official **Dodo Payments** OpenCode plugin via `data/plugins/dodo-payments.yaml`, following the YAML format from `contributing.md`.

## Plugin
- **Repo:** https://github.com/dodopayments/dodo-agent-plugin
- **npm:** \`@dodopayments/opencode-plugin\`
- **License:** MIT
- **OpenCode integration:** registered in \`opencode.json\` via the \`plugin\` array; both MCP servers auto-register through the plugin's \`config\` hook

## Entry Requirements
- [x] **Relevant** — direct OpenCode plugin support (npm package, \`config\` hook, both MCPs auto-register, eight skills auto-discover)
- [x] **Public** — public GitHub repo
- [x] **Maintained** — active commits, latest release v0.3.3
- [x] **Unique** — not in \`data/plugins/\`
- [x] **Complete** — \`name\`, \`repo\`, \`tagline\`, \`description\` all set