### PR TITLE
docs: add cli-subagent-output to plugins

### DIFF
--- a/data/plugins/cli-subagent-output.yaml
+++ b/data/plugins/cli-subagent-output.yaml
@@ -1,4 +1,4 @@
-name: Andrew Raisbeck
+name: Subagent Reporter
 repo: https://github.com/raisbecka/opencode-subagent-output
 tagline: See exactly what your subagents are up to (in the terminal) when invoked during an `opencode run _____` session.
 description: When opencode run <prompt> is invoked normally, the actions of the primary agent are visible in the terminal, but subagent actions are not. This makes it difficult to follow progress on the prompt, and makes it very difficult to use `opencode run` as part of an unattended process or script. This plugin pipes subagent actions/events directly to stdout, prefixes them with the subagents name, and enumerates subagents when run in parallel for easy identification. This allows the user to follow along in realtime when subagents are running, and effectively trace execution at a later time. 

--- a/data/plugins/cli-subagent-output.yaml
+++ b/data/plugins/cli-subagent-output.yaml
@@ -1,0 +1,4 @@
+name: Andrew Raisbeck
+repo: https://github.com/raisbecka/opencode-subagent-output
+tagline: See exactly what your subagents are up to (in the terminal) when invoked during an `opencode run _____` session.
+description: When opencode run <prompt> is invoked normally, the actions of the primary agent are visible in the terminal, but subagent actions are not. This makes it difficult to follow progress on the prompt, and makes it very difficult to use `opencode run` as part of an unattended process or script. This plugin pipes subagent actions/events directly to stdout, prefixes them with the subagents name, and enumerates subagents when run in parallel for easy identification. This allows the user to follow along in realtime when subagents are running, and effectively trace execution at a later time. 


### PR DESCRIPTION
## Submission Type

- [x] Plugin
- [ ] Project
- [ ] Theme
- [ ] Agent
- [ ] Resource

## Details

**Name: Andrew Raisbeck** 
**Repository: https://github.com/raisbecka/opencode-subagent-output** 
**Tagline: See exactly what your subagents are up to (in the terminal) when invoked during an `opencode run _____` session.** 

## Checklist

- [x] Relevant to OpenCode
- [x] Repository is public and accessible
- [x] Actively maintained
- [x] Not a duplicate
- [x] YAML file in correct folder (`data/{category}/`)
- [x] Filename is kebab-case (e.g., `my-plugin.yaml`)

## YAML Format

Create a file in `data/{category}/your-entry.yaml`:

```yaml
name: Your Entry Name
repo: https://github.com/owner/repo
tagline: Short punchy summary (shown in collapsed view)
description: Longer description explaining what it does.
```

See [contributing.md](contributing.md) for full instructions.
