### PR TITLE
docs: add toutkit to projects

### DIFF
--- a/data/projects/nextprob.yaml
+++ b/data/projects/nextprob.yaml
@@ -1,4 +1,4 @@
-name: ToutKit
-repo: https://github.com/toutkit/toutkit
-tagline: Desktop note-taking app for HTML notes, edited by your local AI coding-agent CLI (OpenCode and others)
+name: NextProb
+repo: https://github.com/NextProb/nextprob
+tagline: Desktop notebook for vibe-coded websites, edited by your local AI coding-agent CLI (OpenCode and others)
 description: Electron desktop app that turns a workspace folder of plain .html files into an AI-editable notebook. Agent-agnostic — edit notes with OpenCode or any other agent CLI in an embedded terminal. Notes are real HTML pages. Each note is a self-contained folder that can include a SQLite database, key/value store, attached files, and scripts — so it can grow from a static page into a sortable table, interactive dashboard, or research tool.

--- a/data/projects/toutkit.yaml
+++ b/data/projects/toutkit.yaml
@@ -1,0 +1,4 @@
+name: ToutKit
+repo: https://github.com/toutkit/toutkit
+tagline: Desktop note-taking app for HTML notes, edited by your local AI coding-agent CLI (OpenCode and others)
+description: Electron desktop app that turns a workspace folder of plain .html files into an AI-editable notebook. Agent-agnostic — edit notes with OpenCode or any other agent CLI in an embedded terminal. Notes are real HTML pages. Each note is a self-contained folder that can include a SQLite database, key/value store, attached files, and scripts — so it can grow from a static page into a sortable table, interactive dashboard, or research tool.


### PR DESCRIPTION
## Entry

Adds **NextProb** under Projects.

Repo: https://github.com/NextProb/nextprob

NextProb is an Electron desktop app where every note is a plain `.html` file in a workspace folder, edited by your locally-installed coding-agent CLI running in an embedded terminal. Each note is a self-contained folder that can also include a SQLite database, key/value store, attached files, and scripts — so it can grow from a static page into a sortable table, interactive dashboard, or research tool. It treats OpenCode and other agent CLIs as interchangeable providers behind a common interface.

Closest precedent in the list: GolemBot (agent-agnostic wrapper).

## Checklist

- [x] Relevant — supports OpenCode as a provider
- [x] Public — https://github.com/NextProb/nextprob
- [x] Maintained — commits within the last 6 months
- [x] Unique — no existing entry
- [x] Complete — name, repo, tagline (<120 chars), description