### PR TITLE
docs: add theSaver plugin

### DIFF
--- a/data/plugins/thesaver.yaml
+++ b/data/plugins/thesaver.yaml
@@ -1,0 +1,4 @@
+name: theSaver
+repo: https://github.com/DrunkkToys/theSaver-oc
+tagline: Cost-aware model routing & delegation enforcer
+description: Classifies models into brain/medium/cheap tiers and enforces delegation policy — high-tier models are warned before doing direct edits/writes that a cheaper worker could handle. Tracks per-session and lifetime savings with a footer in every response. Includes the trinity CLI for switching model slots across Claude Code and OpenCode simultaneously.


### PR DESCRIPTION
Adds theSaver — a cost-aware model routing plugin with three-tier delegation enforcement for OpenCode.

- Model tier classification (HIGH / MID / BUDGET)
- Mandatory delegation enforcement for high-tier models
- Session-report cost tracking with cache ROI metrics
- Compatible with Claude Code via model-tiers.json