### PR TITLE
Add theSaver plugin to plugins list

### DIFF
--- a/data/plugins/thesaver.yaml
+++ b/data/plugins/thesaver.yaml
@@ -1,0 +1,4 @@
+name: theSaver
+repo: https://github.com/DrunkkToys/theSaver-oc
+tagline: Cost-aware delegation enforcer with model routing
+description: Three-tier model routing, prompt-cache tracking, ROI reporting in every response, trinity CLI for brain/medium/cheap slot switching, context compression, and test reminders.


### PR DESCRIPTION
## Add theSaver to plugins

Adds [**theSaver**](https://github.com/DrunkkToys/theSaver-oc) to the plugins list.

**theSaver** is a cost-aware delegation enforcer plugin for OpenCode with three-tier model routing, prompt-cache tracking, ROI reporting, and a trinity CLI for brain/medium/cheap slot switching.