### PR TITLE
docs: add opencode-claude-memory plugin

### DIFF
--- a/data/plugins/opencode-claude-memory.yaml
+++ b/data/plugins/opencode-claude-memory.yaml
@@ -1,0 +1,4 @@
+name: OpenCode Claude Memory
+repo: https://github.com/kuitos/opencode-claude-memory
+tagline: Claude Code-compatible memory
+description: Share persistent Markdown memory between OpenCode and Claude Code using Claude Code-compatible paths and file formats.


### PR DESCRIPTION
## Summary

Add `opencode-claude-memory` to the plugins registry.

It shares Claude Code-compatible persistent Markdown memory between OpenCode and Claude Code.

## Validation

- `npm run validate -- data/plugins/opencode-claude-memory.yaml`