### PR TITLE
docs: add Akephalos resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -1073,6 +1073,15 @@
 <br>
 
 <details>
+  <summary><b>Akephalos</b> <img src="https://badgen.net/github/stars/sunnja69/akephalos" height="14"/> - <i>Local-first markdown passport for portable agent context and memory</i></summary>
+  <blockquote>
+    A local-first, markdown-first `.akephalos` passport for portable agent preferences, tool notes, rules, project context, and durable memories. It uses plain files and Git so MCP-capable coding-agent workflows can inspect and carry context across tools and machines without hosted sync.
+    <br><br>
+    <a href="https://github.com/sunnja69/akephalos">🔗 <b>View Repository</b></a>
+  </blockquote>
+</details>
+
+<details>
   <summary><b>Debug Log to Text File</b> - <i>Troubleshooting guide</i></summary>
   <blockquote>
     How to output a debug log from opencode to a text file for troubleshooting.

--- a/data/resources/akephalos.yaml
+++ b/data/resources/akephalos.yaml
@@ -1,0 +1,15 @@
+name: Akephalos
+repo: https://github.com/sunnja69/akephalos
+tagline: Local-first markdown passport for portable agent context and memory
+description: A local-first, markdown-first `.akephalos` passport for portable
+  agent preferences, tool notes, rules, project context, and durable memories.
+  It uses plain files and Git so MCP-capable coding-agent workflows can inspect
+  and carry context across tools and machines without hosted sync.
+scope:
+  - project
+tags:
+  - mcp-server
+  - memory
+  - context
+  - local-first
+  - markdown


### PR DESCRIPTION
Adds Akephalos as a resource for MCP-capable coding-agent workflows.

Akephalos is a local-first, markdown-first `.akephalos` passport for preferences, tool notes, rules, project context, and durable memories. The listing intentionally describes sync as plain files/Git and avoids implying hosted cloud sync or production maturity.

Validation run:
- `npm run validate`
- `npm run generate`