### PR TITLE
docs: add opencode-gpt-imagegen to plugins

### DIFF
--- a/data/plugins/opencode-gpt-imagegen.yaml
+++ b/data/plugins/opencode-gpt-imagegen.yaml
@@ -1,0 +1,14 @@
+name: GPT Imagegen
+repo: https://github.com/yuji-hatakeyama/opencode-gpt-imagegen
+tagline: gpt-image-2 in OpenCode — no API cost when using your ChatGPT subscription
+description: Brings gpt-image-2 (ChatGPT Images 2) image generation to OpenCode. When you sign into OpenCode with your ChatGPT account, generations are billed against your existing Plus / Pro / Business plan — no per-image API cost. An OpenAI API key path is also planned. Supports reference images for style guidance and edits.
+tags:
+  - openai
+  - gpt-image-2
+  - gpt-image
+  - image-generation
+  - image-editing
+  - text-to-image
+  - chatgpt
+  - chatgpt-images
+  - chatgpt-oauth


### PR DESCRIPTION
Adds [opencode-gpt-imagegen](https://github.com/yuji-hatakeyama/opencode-gpt-imagegen) ([npm](https://www.npmjs.com/package/opencode-gpt-imagegen)) to `data/plugins/`.

## What it does

OpenCode plugin that brings `gpt-image-2` (ChatGPT Images 2) image generation into OpenCode. When the user has signed into OpenCode with their ChatGPT account, generations are billed against the existing Plus / Pro / Business plan, so there is no per-image API cost. An OpenAI API key path is also planned for a later release. Supports reference images for style-guided generation and edits.

## Entry checklist

- [x] **Relevant** — OpenCode plugin (registered via `opencode.json` `plugin` array)
- [x] **Public** — https://github.com/yuji-hatakeyama/opencode-gpt-imagegen (MIT)
- [x] **Maintained** — initial release `v0.1.2` published on npm 2026-05-15
- [x] **Unique** — no existing entry in `data/plugins/` for gpt-image / image generation via ChatGPT subscription
- [x] **Complete** — required schema fields filled; `node scripts/validate.js` passes locally

## Notes

- Self-submission (I am the author).
- **Early traction: 359 downloads on npm in the first 3 days after release (2026-05-13 → 2026-05-15).**
- Same category as existing subscription/OAuth-path plugins already in the list (e.g. `gemini-auth`, `kilo-auth`, `antigravity-auth`).
- Tags mirror the package's `package.json` keywords, minus the ones implied by the `plugins/` placement.
