### PR TITLE
docs: add opencode-goal-plugin to plugins

### DIFF
--- a/data/plugins/opencode-goal-plugin.yaml
+++ b/data/plugins/opencode-goal-plugin.yaml
@@ -1,0 +1,4 @@
+name: Opencode Goal Plugin
+repo: https://github.com/willytop8/OpenCode-goal-plugin
+tagline: Session-scoped /goal command
+description: Experimental /goal command plugin for OpenCode that keeps an objective in session context, auto-continues on idle, and stops on completion markers, blockers, or safety limits.


### PR DESCRIPTION
## Summary
- Add opencode-goal-plugin to the plugins list
- Describe it as an experimental session-scoped /goal command with auto-continue and safety limits

## Validation
- npm run validate -- data/plugins/opencode-goal-plugin.yaml