### PR TITLE
docs: add opencode-review to plugins

### DIFF
--- a/data/plugins/opencode-review.yaml
+++ b/data/plugins/opencode-review.yaml
@@ -1,0 +1,4 @@
+name: opencode-review
+repo: https://github.com/sun-praise/opencode-review
+tagline: Automatic structured code review with configurable dimensions and auto-fix
+description: An automatic code review plugin for OpenCode CLI. Reviews staged changes when session goes idle, with configurable cooldown, multi-dimension analysis (code quality, security, performance, testing, documentation), severity levels, and auto-fix chain support.


### PR DESCRIPTION
## Summary

- Add `opencode-review` plugin to the plugins list

`opencode-review` is an automatic code review plugin for OpenCode CLI that:
- Auto-reviews staged changes when a session goes idle (with configurable cooldown)
- Supports multi-dimension analysis: code quality, security, performance, testing, documentation
- Provides structured output with severity levels (critical / suggestion / highlight)
- Includes an auto-fix chain that spawns a `review:fixer` sub-agent for critical issues
- Supports both `/review` slash command and Tab-switchable `review` agent mode
- Configurable via `.opencode/review.json`

Repo: https://github.com/sun-praise/opencode-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)