### PR TITLE
docs: add opencode-actions to projects

### DIFF
--- a/data/projects/opencode-actions.yaml
+++ b/data/projects/opencode-actions.yaml
@@ -1,0 +1,4 @@
+name: Opencode Actions
+repo: https://github.com/Svtter/opencode-actions
+tagline: Reusable GitHub Actions for installing and running OpenCode in CI/CD workflows
+description: A collection of reusable GitHub Actions that make it easy to integrate OpenCode into your CI/CD pipelines. Includes actions for PR review, architecture review, spec coverage checking, and one-step opencode setup and execution. Supports caching, retry logic, and multiple LLM providers.


### PR DESCRIPTION
## Summary

Add [opencode-actions](https://github.com/Svtter/opencode-actions) to the Projects section.

Opencode Actions is a collection of reusable GitHub Actions that make it easy to integrate OpenCode into CI/CD pipelines. It includes:

- **review** — opinionated PR review with built-in prompt and model defaults
- **architect-review** — architecture-level PR review focusing on coupling, layering, and structural concerns
- **feature-missing** — audits PR implementation against linked issue spec
- **spec-coverage** — cross-references project spec/task files against PR implementation
- **setup-opencode** — installs OpenCode with caching
- **run-opencode** — runs OpenCode with retry logic for flaky network failures
- **github-run-opencode** — one-step wrapper for `opencode github run`

## Checklist

- [x] Relevant — directly related to OpenCode
- [x] Public — repository is publicly accessible
- [x] Maintained — active commits
- [x] Unique — not a duplicate of existing entry
- [x] Complete — all required YAML fields included

🤖 Generated with [Claude Code](https://claude.com/claude-code)