### PR TITLE
docs: add agent-harness to projects

### DIFF
--- a/data/projects/agent-harness.yaml
+++ b/data/projects/agent-harness.yaml
@@ -1,0 +1,11 @@
+name: agent-harness
+repo: https://github.com/ar27111994/agent-harness
+tagline: Reusable agent asset lifecycle for OpenCode workspaces
+description: A Node.js CLI for discovering, curating, staging, activating, and wiring reusable AI-agent assets into developer workspaces, including OpenCode.
+tags:
+  - cli
+  - agent-assets
+  - workspace
+  - discovery
+  - opencode
+homepage: https://www.npmjs.com/package/@ar27111994/agent-harness


### PR DESCRIPTION
## Summary

- Add `agent-harness` as an OpenCode-related project entry in `data/projects`.

## Notes

`agent-harness` is a Node.js CLI for discovering, curating, staging, activating, and wiring reusable AI-agent assets into developer workspaces, including OpenCode.

Repository: https://github.com/ar27111994/agent-harness

## Validation

- `node scripts/validate.js data/projects/agent-harness.yaml`

I did not edit `README.md`; it regenerates from YAML after merge.
