### PR TITLE
docs: add agenttrace to projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -782,6 +782,15 @@
 </details>
 
 <details>
+  <summary><b>AgentTrace</b> <img src="https://badgen.net/github/stars/luoyuctl/agenttrace" height="14"/> - <i>Local-first session analytics TUI</i></summary>
+  <blockquote>
+    Local-first TUI and report generator for OpenCode and other AI coding-agent session history, including cost, tokens, latency, failures, and slow-run diagnosis.
+    <br><br>
+    <a href="https://github.com/luoyuctl/agenttrace">🔗 <b>View Repository</b></a>
+  </blockquote>
+</details>
+
+<details>
   <summary><b>Beads</b> <img src="https://badgen.net/github/stars/steveyegge/beads" height="14"/> - <i>Project task management</i></summary>
   <blockquote>
     Steve Yegge's project/task management system for agents (with beads_viewer UI).

--- a/data/projects/agenttrace.yaml
+++ b/data/projects/agenttrace.yaml
@@ -1,0 +1,4 @@
+name: AgentTrace
+repo: https://github.com/luoyuctl/agenttrace
+tagline: Local-first session analytics TUI
+description: Local-first TUI and report generator for OpenCode and other AI coding-agent session history, including cost, tokens, latency, failures, and slow-run diagnosis.


### PR DESCRIPTION
Adds AgentTrace to the Projects category as a local-first TUI/report generator for OpenCode and other AI coding-agent session history.\n\nValidation:\n- npm ci\n- npm run validate\n- npm run generate\n- git diff --check