### PR TITLE
docs: add opencode-usage-monitor and opencode-agents-sidebar plugins

### DIFF
--- a/data/plugins/opencode-agents-sidebar.yaml
+++ b/data/plugins/opencode-agents-sidebar.yaml
@@ -1,0 +1,4 @@
+name: Opencode Agents Sidebar
+repo: https://github.com/Mark1708/opencode-agents-sidebar
+tagline: Browse and inspect available agents and their roles
+description: TUI sidebar plugin that displays all configured agents organized by category. Shows agent descriptions, models, and capabilities in a collapsible tree view for quick reference during sessions.

--- a/data/plugins/opencode-usage-monitor.yaml
+++ b/data/plugins/opencode-usage-monitor.yaml
@@ -1,0 +1,4 @@
+name: Opencode Usage Monitor
+repo: https://github.com/Mark1708/opencode-usage-monitor
+tagline: Real-time API usage and cost tracking sidebar
+description: TUI sidebar plugin that monitors token usage and costs across providers (OpenAI, ZAI). Collapsible tree view with per-model breakdowns, configurable refresh keybind, and read-only safe display.


### PR DESCRIPTION
## Plugins Added

### Opencode Usage Monitor
- **Repo**: https://github.com/Mark1708/opencode-usage-monitor
- **npm**: https://www.npmjs.com/package/opencode-usage-monitor
- TUI sidebar plugin for real-time API usage and cost monitoring across providers (OpenAI, ZAI)
- Collapsible tree view with per-model breakdowns
- Configurable refresh keybind
- Read-only safe display with sanitized error messages

### Opencode Agents Sidebar
- **Repo**: https://github.com/Mark1708/opencode-agents-sidebar
- **npm**: https://www.npmjs.com/package/opencode-agents-sidebar
- TUI sidebar plugin for browsing and inspecting available agents
- Displays agents organized by category with descriptions and capabilities
- Collapsible tree view for quick reference during sessions

Both plugins are published on npm and actively maintained.