### PR TITLE
docs: add OrgX OpenCode plugin

### DIFF
--- a/data/plugins/orgx-opencode-plugin.yaml
+++ b/data/plugins/orgx-opencode-plugin.yaml
@@ -11,11 +11,3 @@ tags:
   - receipts
   - mcp
 homepage: https://github.com/useorgx/orgx-opencode-plugin#readme
-installation: |
-  ```bash
-  npm install -g @useorgx/orgx-opencode-plugin
-
-  export ORGX_API_KEY=oxk_...
-  export ORGX_WORKSPACE_ID=<uuid>
-  orgx-opencode-plugin
-  ```

--- a/data/plugins/orgx-opencode-plugin.yaml
+++ b/data/plugins/orgx-opencode-plugin.yaml
@@ -1,0 +1,21 @@
+name: OrgX OpenCode Plugin
+repo: https://github.com/useorgx/orgx-opencode-plugin
+tagline: OrgX Work Graph peer for task dispatch, receipts, deviations, and passive reconciliation
+description: OrgX OpenCode Plugin connects OpenCode sessions to the OrgX execution control plane. It receives OrgX task dispatches, drives the user's local OpenCode session, posts execution receipts and deviations back to OrgX, and writes compact Work Graph events for later audit-first reconciliation.
+scope:
+  - global
+tags:
+  - agent-orchestration
+  - work-graph
+  - task-dispatch
+  - receipts
+  - mcp
+homepage: https://github.com/useorgx/orgx-opencode-plugin#readme
+installation: |
+  ```bash
+  npm install -g @useorgx/orgx-opencode-plugin
+
+  export ORGX_API_KEY=oxk_...
+  export ORGX_WORKSPACE_ID=<uuid>
+  orgx-opencode-plugin
+  ```


### PR DESCRIPTION
## Summary
- Add the OrgX OpenCode Plugin to the plugins directory
- Link the public `useorgx/orgx-opencode-plugin` repository and homepage without npm install instructions, so the listing is not blocked by the current npm trusted-publishing issue

## Validation
- `npm run validate`
- `git diff --check`