### PR TITLE
Add multilingual README support (Chinese & Russian)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@
 <!-- LANGUAGE SWITCHER -->
 <p>
 <a href="README.md"><img src="https://img.shields.io/badge/EN-English-blue" height="22" alt="English" /></a>
+&nbsp;&nbsp;
 <a href="README.zh-CN.md"><img src="https://img.shields.io/badge/中文-简体-green" height="22" alt="简体中文" /></a>
+&nbsp;&nbsp;
 <a href="README.ru-RU.md"><img src="https://img.shields.io/badge/Русский-версия-orange" height="22" alt="Русский" /></a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@
 <a href="https://github.com/anomalyco/opencode"><img src="https://img.shields.io/github/stars/anomalyco/opencode?style=social" height="28" alt="Opencode Stars" /></a>
 </p>
 
+<!-- LANGUAGE SWITCHER -->
+<p>
+<a href="README.md"><img src="https://img.shields.io/badge/EN-English-blue" height="22" alt="English" /></a>
+<a href="README.zh-CN.md"><img src="https://img.shields.io/badge/中文-简体-green" height="22" alt="简体中文" /></a>
+<a href="README.ru-RU.md"><img src="https://img.shields.io/badge/Русский-версия-orange" height="22" alt="Русский" /></a>
+</p>
+
+
 <br>
 
 <!-- DESCRIPTION -->

--- a/README.ru-RU.md
+++ b/README.ru-RU.md
@@ -19,7 +19,9 @@
 <!-- LANGUAGE SWITCHER -->
 <p>
 <a href="README.md"><img src="https://img.shields.io/badge/EN-English-blue" height="22" alt="English" /></a>
+&nbsp;&nbsp;
 <a href="README.zh-CN.md"><img src="https://img.shields.io/badge/中文-简体-green" height="22" alt="简体中文" /></a>
+&nbsp;&nbsp;
 <a href="README.ru-RU.md"><img src="https://img.shields.io/badge/Русский-версия-orange" height="22" alt="Русский" /></a>
 </p>
 

--- a/README.ru-RU.md
+++ b/README.ru-RU.md
@@ -1,0 +1,137 @@
+<!-- HEADER -->
+<div align="center">
+
+<br>
+<!-- LOGO -->
+<img src="https://github.com/user-attachments/assets/aced1e8e-e6be-485a-9015-b822d01ab064" alt="Awesome Opencode" />
+<br><br>
+
+<!-- TITLE -->
+<h1>Awesome Opencode</h1>
+
+<!-- BADGES -->
+<p>
+<a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" height="28" alt="Awesome" /></a>
+&nbsp;&nbsp;
+<a href="https://github.com/anomalyco/opencode"><img src="https://img.shields.io/github/stars/anomalyco/opencode?style=social" height="28" alt="Opencode Stars" /></a>
+</p>
+
+<!-- LANGUAGE SWITCHER -->
+<p>
+<a href="README.md"><img src="https://img.shields.io/badge/EN-English-blue" height="22" alt="English" /></a>
+<a href="README.zh-CN.md"><img src="https://img.shields.io/badge/中文-简体-green" height="22" alt="简体中文" /></a>
+<a href="README.ru-RU.md"><img src="https://img.shields.io/badge/Русский-версия-orange" height="22" alt="Русский" /></a>
+</p>
+
+<br>
+
+<!-- DESCRIPTION -->
+<h3>Курируемый список плагинов, тем, агентов и ресурсов для <a href="https://opencode.ai/">Opencode</a>.</h3>
+<h3>AI-кодинг-агент для терминала, созданный командой <a href="https://github.com/anomalyco">Anomaly</a>.</h3>
+
+<br>
+
+[**ОФИЦИАЛЬНЫЕ**](#официальные) • [**ПЛАГИНЫ**](#plugins) • [**ТЕМЫ**](#themes) • [**АГЕНТЫ**](#agents) • [**ПРОЕКТЫ**](#projects) • [**РЕСУРСЫ**](#resources)
+
+<br>
+<hr>
+
+</div>
+
+<!-- CONTENT -->
+
+<div id="официальные"></div>
+
+<h3>⭐️ Официальные репозитории</h3>
+
+| Проект | Stars | Описание |
+| :--- | :--- | :--- |
+| **[opencode](https://github.com/anomalyco/opencode)** | ![Stars](https://badgen.net/github/stars/anomalyco/opencode) | Официальный AI-кодинг-агент Opencode. |
+| **[opencode-sdk-js](https://github.com/anomalyco/opencode-sdk-js)** | ![Stars](https://badgen.net/github/stars/anomalyco/opencode-sdk-js) | Официальный JavaScript/TypeScript SDK для Opencode. |
+| **[opencode-sdk-go](https://github.com/anomalyco/opencode-sdk-go)** | ![Stars](https://badgen.net/github/stars/anomalyco/opencode-sdk-go) | Официальный Go SDK для Opencode. |
+| **[opencode-sdk-python](https://github.com/anomalyco/opencode-sdk-python)** | ![Stars](https://badgen.net/github/stars/anomalyco/opencode-sdk-python) | Официальный Python SDK для Opencode. |
+
+<br>
+
+<div id="plugins"></div>
+
+<details open>
+<summary><strong>🧩 ПЛАГИНЫ</strong></summary>
+<br>
+
+> 📖 Содержание списка плагинов автоматически генерируется из основного README на английском.
+> Полный список см. в [English README](README.md#plugins).
+
+<br>
+<a href="https://github.com/awesome-opencode/awesome-opencode/blob/main/contributing.md"><b>➕ Добавить плагин через PR</b></a>
+</details>
+
+<br>
+
+<div id="themes"></div>
+
+<details>
+<summary><strong>🎨 ТЕМЫ</strong></summary>
+<br>
+
+> 📖 Содержание списка тем автоматически генерируется из основного README на английском.
+> Полный список см. в [English README](README.md#themes).
+
+<br>
+<a href="https://github.com/awesome-opencode/awesome-opencode/blob/main/contributing.md"><b>➕ Добавить тему через PR</b></a>
+</details>
+
+<br>
+
+<div id="agents"></div>
+
+<details>
+<summary><strong>🤖 АГЕНТЫ</strong></summary>
+<br>
+
+> 📖 Содержание списка агентов автоматически генерируется из основного README на английском.
+> Полный список см. в [English README](README.md#agents).
+
+<br>
+<a href="https://github.com/awesome-opencode/awesome-opencode/blob/main/contributing.md"><b>➕ Добавить агента через PR</b></a>
+</details>
+
+<br>
+
+<div id="projects"></div>
+
+<details>
+<summary><strong>🛠 ПРОЕКТЫ</strong></summary>
+<br>
+
+> 📖 Содержание списка проектов автоматически генерируется из основного README на английском.
+> Полный список см. в [English README](README.md#projects).
+
+<br>
+<a href="https://github.com/awesome-opencode/awesome-opencode/blob/main/contributing.md"><b>➕ Добавить проект через PR</b></a>
+</details>
+
+<br>
+
+<div id="resources"></div>
+
+<details>
+<summary><strong>📚 РЕСУРСЫ</strong></summary>
+<br>
+
+> 📖 Содержание списка ресурсов автоматически генерируется из основного README на английском.
+> Полный список см. в [English README](README.md#resources).
+
+<br>
+<a href="https://github.com/awesome-opencode/awesome-opencode/blob/main/contributing.md"><b>➕ Добавить ресурс через PR</b></a>
+</details>
+
+<br><br>
+
+<div align="center">
+<h3>🤝 Участие</h3>
+Нашли отличный проект для Opencode? <br>
+<a href="https://github.com/awesome-opencode/awesome-opencode/blob/main/contributing.md"><b>Отправьте Pull Request</b></a>, чтобы добавить его в список!
+<br><br>
+<sub>Выпущено под лицензией <a href="https://creativecommons.org/publicdomain/zero/1.0/">CC0 1.0 Universal</a>.</sub>
+</div>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -19,19 +19,21 @@
 <!-- LANGUAGE SWITCHER -->
 <p>
 <a href="README.md"><img src="https://img.shields.io/badge/EN-English-blue" height="22" alt="English" /></a>
+&nbsp;&nbsp;
 <a href="README.zh-CN.md"><img src="https://img.shields.io/badge/中文-简体-green" height="22" alt="简体中文" /></a>
+&nbsp;&nbsp;
 <a href="README.ru-RU.md"><img src="https://img.shields.io/badge/Русский-версия-orange" height="22" alt="Русский" /></a>
 </p>
 
 <br>
 
 <!-- DESCRIPTION -->
-<h3>Opencode 的插件、主题、代理和资源精选列表。</h3>
-<h3>Opencode 是终端上的 AI 编程代理，由 <a href="https://github.com/anomalyco">Anomaly</a> 团队构建。</h3>
+<h3>Opencode 插件、主题、智能体和资源的精选列表。</h3>
+<h3>Opencode 是终端上的 AI 编程智能体，由 <a href="https://github.com/anomalyco">Anomaly</a> 团队打造。</h3>
 
 <br>
 
-[**官方仓库**](#官方仓库) • [**插件**](#plugins) • [**主题**](#themes) • [**代理**](#agents) • [**项目**](#projects) • [**资源**](#resources)
+[**官方仓库**](#官方仓库) • [**插件**](#plugins) • [**主题**](#themes) • [**智能体**](#agents) • [**项目**](#projects) • [**资源**](#resources)
 
 <br>
 <hr>
@@ -46,7 +48,7 @@
 
 | 项目 | Stars | 描述 |
 | :--- | :--- | :--- |
-| **[opencode](https://github.com/anomalyco/opencode)** | ![Stars](https://badgen.net/github/stars/anomalyco/opencode) | 官方 Opencode AI 编程代理。 |
+| **[opencode](https://github.com/anomalyco/opencode)** | ![Stars](https://badgen.net/github/stars/anomalyco/opencode) | 官方 Opencode AI 编程智能体。 |
 | **[opencode-sdk-js](https://github.com/anomalyco/opencode-sdk-js)** | ![Stars](https://badgen.net/github/stars/anomalyco/opencode-sdk-js) | Opencode 官方 JavaScript/TypeScript SDK。 |
 | **[opencode-sdk-go](https://github.com/anomalyco/opencode-sdk-go)** | ![Stars](https://badgen.net/github/stars/anomalyco/opencode-sdk-go) | Opencode 官方 Go SDK。 |
 | **[opencode-sdk-python](https://github.com/anomalyco/opencode-sdk-python)** | ![Stars](https://badgen.net/github/stars/anomalyco/opencode-sdk-python) | Opencode 官方 Python SDK。 |
@@ -59,8 +61,8 @@
 <summary><strong>🧩 插件</strong></summary>
 <br>
 
-> 📖 插件列表内容由英文主 README 自动生成。
-> 请查看 [English README](README.md#plugins) 获取完整列表。
+> 📖 插件列表由英文主 README 自动生成。
+> 完整列表请查看 [English README](README.md#plugins)。
 
 <br>
 <a href="https://github.com/awesome-opencode/awesome-opencode/blob/main/contributing.md"><b>➕ 通过 PR 添加插件</b></a>
@@ -74,8 +76,8 @@
 <summary><strong>🎨 主题</strong></summary>
 <br>
 
-> 📖 主题列表内容由英文主 README 自动生成。
-> 请查看 [English README](README.md#themes) 获取完整列表。
+> 📖 主题列表由英文主 README 自动生成。
+> 完整列表请查看 [English README](README.md#themes)。
 
 <br>
 <a href="https://github.com/awesome-opencode/awesome-opencode/blob/main/contributing.md"><b>➕ 通过 PR 添加主题</b></a>
@@ -86,14 +88,14 @@
 <div id="agents"></div>
 
 <details>
-<summary><strong>🤖 代理</strong></summary>
+<summary><strong>🤖 智能体</strong></summary>
 <br>
 
-> 📖 代理列表内容由英文主 README 自动生成。
-> 请查看 [English README](README.md#agents) 获取完整列表。
+> 📖 智能体列表由英文主 README 自动生成。
+> 完整列表请查看 [English README](README.md#agents)。
 
 <br>
-<a href="https://github.com/awesome-opencode/awesome-opencode/blob/main/contributing.md"><b>➕ 通过 PR 添加代理</b></a>
+<a href="https://github.com/awesome-opencode/awesome-opencode/blob/main/contributing.md"><b>➕ 通过 PR 添加智能体</b></a>
 </details>
 
 <br>
@@ -104,8 +106,8 @@
 <summary><strong>🛠 项目</strong></summary>
 <br>
 
-> 📖 项目列表内容由英文主 README 自动生成。
-> 请查看 [English README](README.md#projects) 获取完整列表。
+> 📖 项目列表由英文主 README 自动生成。
+> 完整列表请查看 [English README](README.md#projects)。
 
 <br>
 <a href="https://github.com/awesome-opencode/awesome-opencode/blob/main/contributing.md"><b>➕ 通过 PR 添加项目</b></a>
@@ -119,8 +121,8 @@
 <summary><strong>📚 资源</strong></summary>
 <br>
 
-> 📖 资源列表内容由英文主 README 自动生成。
-> 请查看 [English README](README.md#resources) 获取完整列表。
+> 📖 资源列表由英文主 README 自动生成。
+> 完整列表请查看 [English README](README.md#resources)。
 
 <br>
 <a href="https://github.com/awesome-opencode/awesome-opencode/blob/main/contributing.md"><b>➕ 通过 PR 添加资源</b></a>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,137 @@
+<!-- HEADER -->
+<div align="center">
+
+<br>
+<!-- LOGO -->
+<img src="https://github.com/user-attachments/assets/aced1e8e-e6be-485a-9015-b822d01ab064" alt="Awesome Opencode" />
+<br><br>
+
+<!-- TITLE -->
+<h1>Awesome Opencode</h1>
+
+<!-- BADGES -->
+<p>
+<a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" height="28" alt="Awesome" /></a>
+&nbsp;&nbsp;
+<a href="https://github.com/anomalyco/opencode"><img src="https://img.shields.io/github/stars/anomalyco/opencode?style=social" height="28" alt="Opencode Stars" /></a>
+</p>
+
+<!-- LANGUAGE SWITCHER -->
+<p>
+<a href="README.md"><img src="https://img.shields.io/badge/EN-English-blue" height="22" alt="English" /></a>
+<a href="README.zh-CN.md"><img src="https://img.shields.io/badge/中文-简体-green" height="22" alt="简体中文" /></a>
+<a href="README.ru-RU.md"><img src="https://img.shields.io/badge/Русский-версия-orange" height="22" alt="Русский" /></a>
+</p>
+
+<br>
+
+<!-- DESCRIPTION -->
+<h3>Opencode 的插件、主题、代理和资源精选列表。</h3>
+<h3>Opencode 是终端上的 AI 编程代理，由 <a href="https://github.com/anomalyco">Anomaly</a> 团队构建。</h3>
+
+<br>
+
+[**官方仓库**](#官方仓库) • [**插件**](#plugins) • [**主题**](#themes) • [**代理**](#agents) • [**项目**](#projects) • [**资源**](#resources)
+
+<br>
+<hr>
+
+</div>
+
+<!-- CONTENT -->
+
+<div id="官方仓库"></div>
+
+<h3>⭐️ 官方仓库</h3>
+
+| 项目 | Stars | 描述 |
+| :--- | :--- | :--- |
+| **[opencode](https://github.com/anomalyco/opencode)** | ![Stars](https://badgen.net/github/stars/anomalyco/opencode) | 官方 Opencode AI 编程代理。 |
+| **[opencode-sdk-js](https://github.com/anomalyco/opencode-sdk-js)** | ![Stars](https://badgen.net/github/stars/anomalyco/opencode-sdk-js) | Opencode 官方 JavaScript/TypeScript SDK。 |
+| **[opencode-sdk-go](https://github.com/anomalyco/opencode-sdk-go)** | ![Stars](https://badgen.net/github/stars/anomalyco/opencode-sdk-go) | Opencode 官方 Go SDK。 |
+| **[opencode-sdk-python](https://github.com/anomalyco/opencode-sdk-python)** | ![Stars](https://badgen.net/github/stars/anomalyco/opencode-sdk-python) | Opencode 官方 Python SDK。 |
+
+<br>
+
+<div id="plugins"></div>
+
+<details open>
+<summary><strong>🧩 插件</strong></summary>
+<br>
+
+> 📖 插件列表内容由英文主 README 自动生成。
+> 请查看 [English README](README.md#plugins) 获取完整列表。
+
+<br>
+<a href="https://github.com/awesome-opencode/awesome-opencode/blob/main/contributing.md"><b>➕ 通过 PR 添加插件</b></a>
+</details>
+
+<br>
+
+<div id="themes"></div>
+
+<details>
+<summary><strong>🎨 主题</strong></summary>
+<br>
+
+> 📖 主题列表内容由英文主 README 自动生成。
+> 请查看 [English README](README.md#themes) 获取完整列表。
+
+<br>
+<a href="https://github.com/awesome-opencode/awesome-opencode/blob/main/contributing.md"><b>➕ 通过 PR 添加主题</b></a>
+</details>
+
+<br>
+
+<div id="agents"></div>
+
+<details>
+<summary><strong>🤖 代理</strong></summary>
+<br>
+
+> 📖 代理列表内容由英文主 README 自动生成。
+> 请查看 [English README](README.md#agents) 获取完整列表。
+
+<br>
+<a href="https://github.com/awesome-opencode/awesome-opencode/blob/main/contributing.md"><b>➕ 通过 PR 添加代理</b></a>
+</details>
+
+<br>
+
+<div id="projects"></div>
+
+<details>
+<summary><strong>🛠 项目</strong></summary>
+<br>
+
+> 📖 项目列表内容由英文主 README 自动生成。
+> 请查看 [English README](README.md#projects) 获取完整列表。
+
+<br>
+<a href="https://github.com/awesome-opencode/awesome-opencode/blob/main/contributing.md"><b>➕ 通过 PR 添加项目</b></a>
+</details>
+
+<br>
+
+<div id="resources"></div>
+
+<details>
+<summary><strong>📚 资源</strong></summary>
+<br>
+
+> 📖 资源列表内容由英文主 README 自动生成。
+> 请查看 [English README](README.md#resources) 获取完整列表。
+
+<br>
+<a href="https://github.com/awesome-opencode/awesome-opencode/blob/main/contributing.md"><b>➕ 通过 PR 添加资源</b></a>
+</details>
+
+<br><br>
+
+<div align="center">
+<h3>🤝 贡献</h3>
+发现了优秀的 Opencode 相关项目？<br>
+<a href="https://github.com/awesome-opencode/awesome-opencode/blob/main/contributing.md"><b>提交 Pull Request</b></a> 将其添加到列表中！
+<br><br>
+<sub>基于 <a href="https://creativecommons.org/publicdomain/zero/1.0/">CC0 1.0 Universal</a> 发布。</sub>
+</div>

--- a/templates/README.template.md
+++ b/templates/README.template.md
@@ -19,7 +19,9 @@
 <!-- LANGUAGE SWITCHER -->
 <p>
 <a href="README.md"><img src="https://img.shields.io/badge/EN-English-blue" height="22" alt="English" /></a>
+&nbsp;&nbsp;
 <a href="README.zh-CN.md"><img src="https://img.shields.io/badge/中文-简体-green" height="22" alt="简体中文" /></a>
+&nbsp;&nbsp;
 <a href="README.ru-RU.md"><img src="https://img.shields.io/badge/Русский-версия-orange" height="22" alt="Русский" /></a>
 </p>
 

--- a/templates/README.template.md
+++ b/templates/README.template.md
@@ -16,6 +16,14 @@
 <a href="https://github.com/anomalyco/opencode"><img src="https://img.shields.io/github/stars/anomalyco/opencode?style=social" height="28" alt="Opencode Stars" /></a>
 </p>
 
+<!-- LANGUAGE SWITCHER -->
+<p>
+<a href="README.md"><img src="https://img.shields.io/badge/EN-English-blue" height="22" alt="English" /></a>
+<a href="README.zh-CN.md"><img src="https://img.shields.io/badge/中文-简体-green" height="22" alt="简体中文" /></a>
+<a href="README.ru-RU.md"><img src="https://img.shields.io/badge/Русский-версия-orange" height="22" alt="Русский" /></a>
+</p>
+
+
 <br>
 
 <!-- DESCRIPTION -->


### PR DESCRIPTION
This PR adds multilingual README support to the awesome-opencode repository.

### Changes:
- **README.zh-CN.md**: New Chinese (Simplified) translation of the README
- **README.ru-RU.md**: New Russian translation of the README
- **templates/README.template.md**: Added language switcher badges section to the template
- **README.md**: Regenerated to include language switcher badges

### Language Switcher:
A badge-based language switcher has been added to the header of all README variants:
- 🇬🇧 English (README.md)
- 🇨🇳 Simplified Chinese (README.zh-CN.md)
- 🇷🇺 Russian (README.ru-RU.md)

Each translated README includes the same header, badges, official repositories table, and references back to the English README for the full plugin/theme/agent/project/resource listings, which are auto-generated from the data directory.