### PR TITLE
data: add NERV to agents

### DIFF
--- a/data/agents/nerv.yaml
+++ b/data/agents/nerv.yaml
@@ -1,0 +1,4 @@
+name: NERV
+repo: https://github.com/juanmanueldaza/nerv
+tagline: Invisible engineering infrastructure for AI agents
+description: Spec-Driven Development pipeline, A2A task delegation hub, persistent semantic memory (MAGI), and 9 specialized subagents for OpenCode. Scaffolds 45+ files via `nerv init` including SDD skills, slash commands, MCP servers, and lifecycle plugins.


### PR DESCRIPTION
Add [NERV](https://github.com/juanmanueldaza/nerv) — invisible engineering infrastructure for AI agents on OpenCode.

- **Section**: Agents
- **Category**: data/agents/nerv.yaml
- **Description**: Spec-Driven Development pipeline, A2A task delegation hub, MAGI persistent memory, and 9 specialized subagents

NERV integrates natively with OpenCode via MCP servers, skills, slash commands, and lifecycle plugins. Running `nerv init` scaffolds 45+ files including SDD skills, commands, and agent configurations.

See https://github.com/juanmanueldaza/nerv for details.