### PR TITLE
feat(themes): Add Charcoal grayscale theme

### DIFF
--- a/data/themes/charcoal.yaml
+++ b/data/themes/charcoal.yaml
@@ -1,0 +1,9 @@
+name: Charcoal
+repo: https://github.com/VyomJain6904/charcoal-theme
+tagline: "Deep-black grayscale theme for OpenCode — no hues, all shades of gray"
+description: |
+  Charcoal is a pure grayscale theme for OpenCode with a near-black (#0d0d0d) background.
+  All 56 theme color keys use shades of gray — no hues anywhere. Designed to match a
+  minimal dark terminal aesthetic.
+
+  Also available for bat and Ghostty in the same repository.


### PR DESCRIPTION
**Theme Name:** Charcoal
**Repository:** https://github.com/VyomJain6904/charcoal-theme

A deep-black grayscale theme with no hues — background `#0d0d0d`, all 56 color keys in shades of gray. Also covers bat and Ghostty in the same repo.

- [x] Theme repo is publicly accessible
- [x] Repository has active commits
- [x] Not a duplicate
- [x] All required YAML fields included