### PR TITLE
Add OpenToken — token-saving plugin with 42 compression layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,15 @@
 </details>
 
 <details>
+  <summary><b>OpenToken</b> <img src="https://badgen.net/github/stars/MrGray17/opentoken" height="14"/> - <i>Token-saving companion — 42 compression layers for input AND output</i></summary>
+  <blockquote>
+    Cuts token usage 70–90% on tool outputs and compresses model responses — 35 input layers (AST skeletons, key aliasing, TOON, LTSC/LZW, family-specific filters) + 7 output layers (conciseness directive, budget cap, boilerplate elimination). Zero risk on every stage: if output grew, original is returned. No behavioral changes, no "caveman speak." Production-proven: 862,301 tokens saved in a single 22-hour session.
+    <br><br>
+    <a href="https://github.com/MrGray17/opentoken">🔗 <b>View Repository</b></a>
+  </blockquote>
+</details>
+
+<details>
   <summary><b>OpenCode Agent Tmux</b> <img src="https://badgen.net/github/stars/AnganSamadder/opencode-agent-tmux" height="14"/> - <i>Real-time tmux panes for OpenCode agents with auto-launch, streaming, and cleanup.</i></summary>
   <blockquote>
     Smart tmux integration for OpenCode that auto-spawns panes to stream agent output, supports flexible layouts and multi-port setups, and cleans up when sessions finish.


### PR DESCRIPTION
## Add OpenToken

OpenToken is a token-saving companion plugin for OpenCode that compresses both tool outputs (35 input layers) and model responses (7 output layers) with zero risk guarantees.

**Key differentiators:**
- **42 compression layers** — AST skeletons, key aliasing, TOON, LTSC/LZW, family-specific filters, boilerplate elimination
- **Both input and output** — compresses tool outputs AND model responses (only plugin that does both)
- **Zero risk** — every stage compares filtered vs original; if it grew, original is returned
- **No behavioral changes** — model speaks normally, no "caveman speak"
- **Production-proven** — 862,301 tokens saved in a single 22-hour session

🔗 https://github.com/MrGray17/opentoken