### PR TITLE
docs: add opencode-research-papers to plugins

### DIFF
--- a/data/plugins/opencode-research-papers.yaml
+++ b/data/plugins/opencode-research-papers.yaml
@@ -1,0 +1,4 @@
+name: Research Papers
+repo: https://github.com/saim-x/opencode-research-papers
+tagline: Search arXiv and OpenAlex for research papers with recency and citation filtering
+description: OpenCode plugin that adds a research_papers tool for searching scholarly literature. Uses arXiv for fresh preprints and OpenAlex for broader metadata, citation counts, and open-access links. Supports filtering by latest, trending, or top-cited papers.


### PR DESCRIPTION
## Research Papers Plugin

Add the opencode-research-papers plugin to the awesome-opencode list.

### Plugin Details
- **Name**: Research Papers
- **Repo**: https://github.com/saim-x/opencode-research-papers
- **Description**: OpenCode plugin that adds a research_papers tool for searching scholarly literature. Uses arXiv for fresh preprints and OpenAlex for broader metadata, citation counts, and open-access links.