### PR TITLE
docs: add discord-presence to plugins

### DIFF
--- a/data/plugins/discord-presence.yaml
+++ b/data/plugins/discord-presence.yaml
@@ -1,0 +1,4 @@
+name: Discord Presence
+repo: https://github.com/Puri12/opencode-discord-presence
+tagline: Discord Rich Presence with multi-agent tracking
+description: Display your OpenCode session in Discord Rich Presence. Multi-agent state machine tracks busy/idle across all sessions with optional mainAgentOnly filter to hide sub-agent (task tool) flicker. Live file spotlight, todo mission board, session recap card, Korean particle handling (을/를, 은/는) built-in.


### PR DESCRIPTION
## What

Adds [opencode-discord-presence](https://github.com/Puri12/opencode-discord-presence) to the plugins directory.

## Why

Discord Rich Presence plugin for OpenCode that distinguishes itself from existing Discord RPC plugins by:

- **Multi-agent state machine** — tracks busy/idle across ALL sessions (main + sub-agents spawned by the task tool), so idle text only appears when EVERY tracked session reports idle. Naive handlers would flicker presence as sub-agents come and go.
- **`mainAgentOnly` opt-in** — resolves `session.parentID` via the OpenCode SDK (with coalescing + 5s negative cache) to filter sub-agent flicker entirely.
- **Rich rotating cards** — file spotlight (off by default for privacy), todo mission board, session stats, model name prefix, session recap card on session end.
- **Korean particle handling** — auto-selects 을/를, 은/는 by final-consonant heuristic (e.g. "Sisyphus를 작업중", "Prometheus는 휴식중").

## Entry checklist

- [x] **Relevant** — OpenCode plugin (published to npm as `opencode-discord-presence`)
- [x] **Public** — https://github.com/Puri12/opencode-discord-presence
- [x] **Maintained** — v0.5.0 released today (2026-05-27), 235 tests passing
- [x] **Unique** — no existing `discord-presence` entry in `data/plugins/`
- [x] **Complete** — YAML has name, repo, tagline (under 120 chars), description

## YAML

\`\`\`yaml
name: Discord Presence
repo: https://github.com/Puri12/opencode-discord-presence
tagline: Discord Rich Presence with multi-agent tracking
description: Display your OpenCode session in Discord Rich Presence. Multi-agent state machine tracks busy/idle across all sessions with optional mainAgentOnly filter to hide sub-agent (task tool) flicker. Live file spotlight, todo mission board, session recap card, Korean particle handling (을/를, 은/는) built-in.
\`\`\`