### PR TITLE
docs: add opencode-usage-monitor plugin

### DIFF
--- a/data/plugins/opencode-usage-monitor.yaml
+++ b/data/plugins/opencode-usage-monitor.yaml
@@ -1,0 +1,4 @@
+name: Opencode Usage Monitor
+repo: https://github.com/Mark1708/opencode-usage-monitor
+tagline: Monitor OpenAI and Z.AI usage quotas in the TUI
+description: OpenCode sidebar plugin that displays API usage quotas for OpenAI and Z.AI providers with per-model breakdowns, spend tracking, and configurable refresh controls.


### PR DESCRIPTION
## Summary
- Add opencode-usage-monitor to the plugin registry
- Link the public GitHub repository for the OpenCode usage quota sidebar plugin

## Validation
- npm run validate -- data/plugins/opencode-usage-monitor.yaml