### PR TITLE
docs: add opencode-agents-sidebar plugin

### DIFF
--- a/data/plugins/opencode-agents-sidebar.yaml
+++ b/data/plugins/opencode-agents-sidebar.yaml
@@ -1,0 +1,4 @@
+name: Opencode Agents Sidebar
+repo: https://github.com/Mark1708/opencode-agents-sidebar
+tagline: Browse configured OhMyOpenAgent agents in the TUI
+description: OpenCode sidebar plugin that displays configured OhMyOpenAgent agents with lifecycle-based categories, collapsible sections, descriptions, and model information.


### PR DESCRIPTION
## Summary
- Add opencode-agents-sidebar to the plugin registry
- Link the public GitHub repository for the OpenCode OhMyOpenAgent sidebar plugin

## Validation
- npm run validate -- data/plugins/opencode-agents-sidebar.yaml