### PR TITLE
docs: add GitHub Release to plugins

### DIFF
--- a/data/plugins/opencode-github-release.yaml
+++ b/data/plugins/opencode-github-release.yaml
@@ -1,0 +1,4 @@
+name: GitHub Release
+repo: https://github.com/amestsantim/opencode-github-release
+tagline: Automated GitHub releases
+description: Create and publish GitHub releases with semantic versioning, tag management, and auto-generated release notes.


### PR DESCRIPTION
Adds [opencode-github-release](https://github.com/amestsantim/opencode-github-release) to the plugins listing — an OpenCode plugin for automated GitHub releases with semantic versioning, tag management, and release notes.