### PR TITLE
docs: add iamhumans — human-shaped conversation skill for opencode, 99/100 eval

### DIFF
--- a/data/agents/iamhumans.yaml
+++ b/data/agents/iamhumans.yaml
@@ -1,0 +1,4 @@
+name: iamhumans
+repo: https://github.com/hoainho/iamhumans
+tagline: Teaches Claude to stop performing empathy and start being present. 99/100 on a 100-case eval.
+description: An opencode skill (~200 lines) that removes sycophancy, lecturing, and performed empathy from Claude's emotional responses. Teaches the shape of human conversation — when to be short, when to sit with something, when the right reply is "oh." Ships with a 100-case eval corpus and a baseline comparison showing +89.4 point skill delta over default Claude (1/20 PASS baseline vs 99/100 with skill). Load for human-shaped conversations (grief, decisions, vent, small talk). Don't load for code generation.


### PR DESCRIPTION
## iamhumans

An opencode skill that teaches Claude to stop performing empathy and start being present.

**GitHub:** https://github.com/hoainho/iamhumans

### What it does

~200 lines of SKILL.md that removes the default Claude failure patterns in emotional/relational conversations:
- Sycophancy ("You've got this! 💪", "Great question!")
- Lecturing (framework + bullet points in grief moments)
- Performed empathy ("I'm here for you" as filler)
- Structured output in emotional moments
- Refusal-when-engagement-warranted ("As an AI I don't experience days...")

Teaches when to be short, when to stay, when the right reply is "oh."

### Evidence

- **With skill (v1.1.1):** 99/100 PASS, 96.3/100 aggregate, 0 hard fails (100-case eval corpus)
- **Without skill (baseline):** 1/20 PASS, 7.6/100 aggregate, 18/20 hard fails (same 20 cases)
- **Skill delta:** +89.4 points average, PASS rate 5% → 100%
- **Held-out oracle verdict:** *"You are same as 100% real humans."*

Full eval corpus (cases, rubrics, results, baseline comparison) open in the repo.

### Category

Fits `data/agents/` — it's a skill/agent behavior modifier, not a plugin or theme.

### Checklist

- [x] Relevant to OpenCode
- [x] Public repository
- [x] Active (all commits within last 30 days)
- [x] Unique (no existing entry for this project)
- [x] YAML complete with all required fields