### PR TITLE
docs: add opencode-chat-export to projects

### DIFF
--- a/data/projects/opencode-chat-export.yaml
+++ b/data/projects/opencode-chat-export.yaml
@@ -1,0 +1,4 @@
+name: Opencode Chat Export
+repo: https://github.com/jjserenity/opencode-chat-export
+tagline: MCP server to export chat history to Markdown
+description: MCP server that exports OpenCode chat history to Markdown files with tool calls, reasoning, and cost summaries. Export current session, specific sessions by ID, or bulk exports. pip installable.


### PR DESCRIPTION
Adds [opencode-chat-export](https://github.com/jjserenity/opencode-chat-export) to the Projects section — an MCP server for exporting OpenCode chat history to Markdown files.

**Features:**
- Export current session (no session ID needed)
- Export specific sessions by ID/slug
- Export N most recent sessions
- Renders tool calls, reasoning, code patches, cost summaries
- Reads directly from OpenCode's SQLite DB
- pip / uv installable