### PR TITLE
Add Reflection-3 — judge layer that catches premature agent stops

### DIFF
--- a/README.md
+++ b/README.md
@@ -1034,6 +1034,15 @@
 </details>
 
 <details>
+  <summary><b>Reflection-3</b> <img src="https://badgen.net/github/stars/dzianisv/opencode-plugins" height="14"/> - <i>Judge layer that catches premature agent stops</i></summary>
+  <blockquote>
+    LLM-as-judge plugin for OpenCode and Claude Code: fires on every agent stop, classifies stops as premature or legitimate using a rubric mined from 227 real sessions (78% were premature), and re-prompts the agent with targeted feedback. Enforces workflow gates (tests, CI, PRs). Implements the Reflexion self-improvement loop. Works on both OpenCode (<code>session.idle</code> event) and Claude Code (<code>Stop</code> hook).
+    <br><br>
+    <a href="https://github.com/dzianisv/opencode-plugins">🔗 <b>View Repository</b></a>
+  </blockquote>
+</details>
+
+<details>
   <summary><b>Tokscale</b> <img src="https://badgen.net/github/stars/junhoyeo/tokscale" height="14"/> - <i>Token usage tracking CLI</i></summary>
   <blockquote>
     A CLI tool for tracking token usage from OpenCode and other coding agents (Claude Code, Codex, Gemini CLI, and Cursor IDE).


### PR DESCRIPTION
## Plugin

**[Reflection-3](https://github.com/dzianisv/opencode-plugins)** — LLM-as-judge verification layer for OpenCode and Claude Code.

### What it does

Fires after every agent turn (`session.idle` for OpenCode, `Stop` hook for Claude Code). Classifies the stop as premature or legitimate, then re-prompts the agent with targeted feedback if it stopped early.

### Why it's useful

- **78% of agent stops are premature** — mined from 227 real sessions; 91 were permission-seeking ("Want me to run the tests?"), 68 were stopped-with-todos
- Enforces workflow gates: tests ran + passed, PR created, CI green
- Detects planning loops (reads files without writing code) and action loops (repeats failing commands)
- Based on Reflexion (Shinn et al. 2023) — actor + evaluator + verbal self-reflection, bounded to 3 retries

### Install

```json
{ "plugin": ["opencode-reflection"] }
```

or for Claude Code:
```
/plugin marketplace add dzianisv/opencode-plugins
/plugin install reflection-cc
```