### PR TITLE
feat: add supereasy-memory plugin

### DIFF
--- a/data/plugins/opencode-memory.yaml
+++ b/data/plugins/opencode-memory.yaml
@@ -1,0 +1,4 @@
+name: opencode-memory
+repo: https://github.com/YOUR_USERNAME/opencode-memory
+tagline: Persistent memory plugin for OpenCode that learns from sessions.
+description: Ported from pi-memory, this plugin automatically learns your corrections, project patterns, and preferences from sessions and injects them into future conversations contextually. Features include smart global/project scopes and full-text searching.

--- a/data/plugins/supereasy-memory.yaml
+++ b/data/plugins/supereasy-memory.yaml
@@ -1,0 +1,4 @@
+name: supereasy-memory
+repo: https://github.com/songsongtao/opencode-memory
+tagline: Persistent memory plugin for OpenCode that learns from sessions.
+description: Ported from pi-memory, this plugin automatically learns your corrections, project patterns, and preferences from sessions and injects them into future conversations contextually. Features include smart global/project scopes and full-text searching.


### PR DESCRIPTION
## Submission Type

- [x] Plugin
- [ ] Project
- [ ] Theme
- [ ] Agent
- [ ] Resource

## Details

**Name:** supereasy-memory
**Repository:** https://github.com/songsongtao/opencode-memory
**Description:** A persistent memory plugin for OpenCode ported from pi-memory. It automatically learns user corrections, project patterns, and preferences, and injects relevant context into future chats with zero extra configuration. Features include project-level isolation, real-time hot updates, and an FTS5-powered SQLite engine.

## Checklist

- [x] I have read the Contributing Guidelines.
- [x] My submission is formatted correctly (kebab-case YAML file in `data/plugins/`).
- [x] The repository is public and accessible.