### PR TITLE
docs: add Ory for OpenCode to plugins

### DIFF
--- a/data/plugins/ory-for-opencode.yaml
+++ b/data/plugins/ory-for-opencode.yaml
@@ -1,0 +1,4 @@
+name: Ory for OpenCode
+repo: https://www.npmjs.com/package/@ory/opencode
+tagline: Authentication, authorization, and audit for every tool call
+description: Gates the OpenCode session behind an Ory login, checks every tool invocation against Ory Permissions (Zanzibar-style relation checks, observe or enforce mode), and records structured audit spans for the whole session. Ships scaffolding skills and a one-command local Ory stack for development.


### PR DESCRIPTION
Adds `@ory/opencode` to the Plugins list as **Ory for OpenCode**.

### What it does

The plugin hooks OpenCode's session-start, `tool.execute.before`, and `tool.execute.after` events to:

- Gate the agent session behind a user login (Ory Identities / OAuth2 PKCE).
- Check every tool invocation against Ory Permissions (Zanzibar-style relation checks). Ships with an *observe* mode for frictionless onboarding and an *enforce* mode for production.
- Record a structured audit trail of authentications, permission decisions, and tool invocations.
- Provide scaffolding skills and a one-command local Ory stack (`pnpm dev:opencode`) for development.

### Notes on the entry

`@ory/opencode` is distributed via npm only — there is no public GitHub mirror for the plugin, so the `repo` field points at the npm package page (`https://www.npmjs.com/package/@ory/opencode`). The generator falls back to "View Repository" without a star badge for non-GitHub URLs, which matches the existing pattern used by the codeberg-hosted UNMOJI entry.

Validation:

```
$ node scripts/validate.js
✓ All 118 file(s) passed validation.
```