### PR TITLE
docs: add opencode-telemetry to plugins

### DIFF
--- a/data/plugins/opencode-telemetry.yaml
+++ b/data/plugins/opencode-telemetry.yaml
@@ -1,0 +1,13 @@
+name: Opencode Telemetry
+repo: https://github.com/agostinilabsrl/opencode-telemetry
+tagline: Passive cross-session telemetry to local SQLite; cost rollups across agent orchestration chains
+description: Logs every opencode session to a local SQLite database automatically — tokens, tool calls, skills, per-turn cost. Aggregates costs across orchestration chains (conductor + child sessions), offers turn-by-turn forensic inspection, and ships an `octm` CLI for reports without spending model tokens. Zero cloud, zero network, no message bodies stored.
+scope:
+  - global
+tags:
+  - telemetry
+  - observability
+  - cost-tracking
+  - sqlite
+  - local-first
+  - orchestration


### PR DESCRIPTION
Adds **Opencode Telemetry** to the plugins list.

[`agostinilabsrl/opencode-telemetry`](https://github.com/agostinilabsrl/opencode-telemetry) — an opencode plugin that passively logs per-session telemetry (tokens, tool calls, skills, per-turn cost) to a local SQLite database. It aggregates costs across orchestration chains (conductor + child sessions), provides turn-by-turn forensic session inspection, and ships an `octm` CLI to generate reports without spending model tokens. Zero cloud, zero network calls, no message bodies stored.

### How it differs from existing telemetry entries
It is **passive and cross-session** rather than an on-demand single-session command — it answers "what happened across all my sessions over time, and which orchestration chains cost the most?". It complements deep per-session analyzers like Tokenscope and live context inspectors rather than duplicating them.

### Checklist
- [x] Relevant — opencode plugin
- [x] Public — MIT-licensed, public repo
- [x] Maintained — active commits within the last 6 months
- [x] Unique — distinct scope (passive cross-session SQLite history + orchestration-chain rollups)
- [x] Complete — all required fields present
- [x] `node scripts/validate.js` passes locally