### PR TITLE
docs: add ul-opencode-event to plugins

### DIFF
--- a/data/plugins/ul-opencode-event.yaml
+++ b/data/plugins/ul-opencode-event.yaml
@@ -16,13 +16,3 @@ tags:
   - token-tracking
   - usage-analytics
 homepage: https://www.npmjs.com/package/@ulthon/ul-opencode-event
-installation: |
-  Add to your `opencode.json`:
-
-  ```json
-  {
-    "plugin": ["@ulthon/ul-opencode-event"]
-  }
-  Then create config at ~/.config/opencode/ul-opencode-event.json, see README (https://gitee.com/ulthon/ul-opencode-event) for details.
-  Quick test:
-npx @ulthon/ul-opencode-event test

--- a/data/plugins/ul-opencode-event.yaml
+++ b/data/plugins/ul-opencode-event.yaml
@@ -1,0 +1,28 @@
+name: ul-opencode-event
+repo: https://gitee.com/ulthon/ul-opencode-event
+tagline: Multi-channel notifications (SMTP, DingTalk, Feishu) and token usage analytics
+description: |
+  Get notified when OpenCode sessions complete, error, or need your attention - via SMTP email, DingTalk robot, or Feishu robot.
+  - Multi-channel: SMTP, DingTalk, Feishu, local JSONL file
+  - Multi-level token analytics: message / session / total / project scopes
+  - 74+ template variables with i18n support (zh/en)
+  - Global + project config merge, automatic DB preload for crash recovery
+  - Built-in CLI test tool
+tags:
+  - notifications
+  - email
+  - dingtalk
+  - feishu
+  - token-tracking
+  - usage-analytics
+homepage: https://www.npmjs.com/package/@ulthon/ul-opencode-event
+installation: |
+  Add to your `opencode.json`:
+
+  ```json
+  {
+    "plugin": ["@ulthon/ul-opencode-event"]
+  }
+  Then create config at ~/.config/opencode/ul-opencode-event.json, see README (https://gitee.com/ulthon/ul-opencode-event) for details.
+  Quick test:
+npx @ulthon/ul-opencode-event test


### PR DESCRIPTION
Add [@ulthon/ul-opencode-event](https://gitee.com/ulthon/ul-opencode-event) — multi-channel notifications (SMTP, DingTalk, Feishu) and multi-level token usage analytics for OpenCode session lifecycle events.

npm: https://www.npmjs.com/package/@ulthon/ul-opencode-event