### PR TITLE
docs: add OpenCode Mobile to projects

### DIFF
--- a/data/projects/opencode-mobile.yaml
+++ b/data/projects/opencode-mobile.yaml
@@ -1,0 +1,9 @@
+name: OpenCode Mobile
+repo: https://github.com/dzianisv/opencode-mobile
+tagline: Android client for OpenCode — drive your self-hosted agent from your phone
+description: Free, open-source (MIT) Android app that connects to an opencode server you run yourself. Stream coding sessions in real time, review file diffs, and approve tool calls from your phone. Install via the F-Droid repo or a signed APK.
+homepage: https://dzianisv.github.io/opencode-mobile/
+tags:
+  - android
+  - mobile
+  - client


### PR DESCRIPTION
Adds **OpenCode Mobile** to the Projects section.

A free, open-source (MIT) **Android client for opencode** — connect to an opencode server you run yourself and drive coding sessions from your phone: real-time streaming, file-diff review, and tool-call approval.

- Repo: https://github.com/dzianisv/opencode-mobile
- Website: https://dzianisv.github.io/opencode-mobile/
- Install: F-Droid repo or signed APK (Android 8.0+)

Entry requirements:
- [x] Relevant — a dedicated opencode client
- [x] Public repository
- [x] Maintained (active commits; current v0.4.3)
- [x] Unique (no existing mobile client entry)
- [x] Complete (name, repo, tagline ≤120, description, homepage, tags)

Added as `data/projects/opencode-mobile.yaml` per contributing.md (README auto-generates). Note: OpenCode Mobile is an independent community project, not affiliated with the opencode/Anomaly team.