### PR TITLE
docs: add opencode-handoff-p2p to projects

### DIFF
--- a/data/projects/opencode-handoff-p2p.yaml
+++ b/data/projects/opencode-handoff-p2p.yaml
@@ -1,0 +1,4 @@
+name: opencode-handoff-p2p
+repo: https://github.com/Eldorado-ling/opencode-handoff-p2p
+tagline: Transfer OpenCode session share URLs P2P via private GitHub inbox repos
+description: An OpenCode skill that transfers session share URLs between machines or collaborators peer-to-peer using personal GitHub private inbox repositories. Features a 5-tier verification pipeline (filename regex, trusted-sender allowlist, byte-level content validation, GitHub commit author+committer attribution, GPG signature), transactional fetch-before-delete (URL fetch failure preserves the inbox file for retry), and a Chinese-language trust-boundary preamble that prevents fetched share content from autonomously triggering local actions. Each user owns one private inbox repo; senders push directly into it via collaborator access. Includes a reference Python verification script for deterministic cross-shell behavior.


### PR DESCRIPTION
## Adding opencode-handoff-p2p

An OpenCode skill that transfers session share URLs P2P between machines or collaborators via personal GitHub private inbox repositories.

### Why it's useful

The current pattern for sharing OpenCode session context is: `/share` → copy URL → paste into chat → recipient manually relays context to their agent. This skill turns it into:
- Sender says "send to bob" → agent verifies, signs, pushes to bob's private inbox
- Bob's next session says "check inbox" → agent pulls, runs 5-tier verification, fetches transcript, injects into current session

### Features

- 5-tier security verification (filename regex / trust allowlist / byte-level content / commit author+committer / GPG signature)
- Transactional fetch-before-delete (URL fetch failure preserves the inbox file for retry — no data loss)
- Chinese-language trust boundary preamble (prevents prompt injection from fetched content)
- Reference Python verification script (deterministic cross-shell behavior, prevents agent-interpretation drift)
- Tested end-to-end with DeepSeek V4 Pro on Windows + Git Bash

### Repo

https://github.com/Eldorado-ling/opencode-handoff-p2p (MIT, v1.0.1 released, signed commits + tags)

### Entry Requirements checklist

- [x] **Relevant** — OpenCode-specific skill
- [x] **Public** — github.com/Eldorado-ling/opencode-handoff-p2p is public
- [x] **Maintained** — commits within the last 24h (v1.0.1 security release responding to community review)
- [x] **Unique** — no existing opencode-handoff in this list
- [x] **Complete** — name, repo, tagline, description all present

### YAML file

`data/projects/opencode-handoff-p2p.yaml`

Note: there's no `data/skills/` category, so I placed this under `projects` (Tools, GUIs, integrations, and utilities) since it's an integration utility. Happy to move to a different category if you'd prefer.