### PR TITLE
Add Unship to projects

### DIFF
--- a/data/projects/unship.yaml
+++ b/data/projects/unship.yaml
@@ -1,0 +1,4 @@
+name: Unship
+repo: https://github.com/mbenhard/unship
+tagline: Compare AI-made UI variants locally
+description: Local CLI and browser picker for comparing temporary UI variants created by coding agents like OpenCode, then keeping one and cleaning up the rest.


### PR DESCRIPTION
## Summary

- Add Unship as an OpenCode-compatible project/tool under `data/projects`.
- Unship is a local CLI and browser picker for comparing temporary UI variants created by coding agents, then keeping one and cleaning up the rest.

## Validation

- `npm ci`
- `npm run validate`
- `npm run generate`
- `git diff --check`

I left `README.md` unchanged in the commit because the contributing guide says it is generated from YAML.
