### PR TITLE
docs: add opencode-light-themes to themes

### DIFF
--- a/data/themes/opencode-light-themes.yaml
+++ b/data/themes/opencode-light-themes.yaml
@@ -1,0 +1,4 @@
+name: OpenCode Light Themes
+repo: https://github.com/fatihtoprakk/opencode-light-themes
+tagline: A curated collection of 21 light color themes for OpenCode
+description: The largest collection of light themes for OpenCode. Includes 21 carefully crafted light themes converted from popular VS Code themes — scaefy-light (Atom One Light), Solarized Light, Vivid Light, Coffee Cream, GitHub Light, Quiet Light, Bluloco Light, Brackets Light Pro, NetBeans Light, Ysgrifennwr, Hop Light, GitHub Plus, Classic Light, HC Flurry, all Milkshake variants, and more. Bilingual (EN/TR) documentation and one-command install script included.


### PR DESCRIPTION
Adds the [opencode-light-themes](https://github.com/fatihtoprakk/opencode-light-themes) collection — the largest curated set of light color themes for OpenCode with 21 themes, bilingual README, and one-command install script.