### PR TITLE
feat: add TWZRD Agent Intel MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,6 +611,14 @@
 </details>
 
 <details>
+  <summary><b>TWZRD Agent Intel</b> - <i>Trust scoring for AI agents on Solana via MCP</i></summary>
+  <blockquote>
+    Trust scoring and preflight verification for AI agents on Solana. Verify agent wallet identity before x402 micropayments. Zero-install streamable-http MCP: <code>{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}</code>
+    <br><br>
+    <a href="https://intel.twzrd.xyz">🔗 <b>View Website</b></a>
+  </blockquote>
+</details>
+<details>
   <summary><b>Vibe Coding Slack Notifier</b> <img src="https://badgen.net/github/stars/Wangmerlyn/vibe-coding-slack-notifier" height="14"/> - <i>Slack DM alerts for OpenCode task completion</i></summary>
   <blockquote>
     OpenCode-compatible Slack notifier plugin and toolkit for Codex, OpenCode, Claude Code, and Gemini workflows.


### PR DESCRIPTION
## Add TWZRD Agent Intel MCP server

[TWZRD Agent Intel](https://intel.twzrd.xyz) is a trust scoring MCP server for AI agents on Solana.

- **Tools**: `score_agent(wallet)`, `preflight_check(wallet)` (free), `get_trust_receipt(wallet)` (x402 paid)
- **Zero-install**: Streamable-HTTP transport, no local install required
- **Use case**: Verify agent wallet identity before x402 micropayments

Config: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`

Fits in PLUGINS as an MCP server plugin for agent trust verification.