### PR TITLE
Add MiMo-Code (voice-driven multimodal desktop coding agent for MiMo)

### DIFF
--- a/data/projects/mimo-code.yaml
+++ b/data/projects/mimo-code.yaml
@@ -1,0 +1,14 @@
+name: MiMo-Code
+repo: https://github.com/shin4/mimo-code
+tagline: Voice-driven multimodal desktop coding agent for MiMo
+description: A native desktop coding agent for the MiMo model family — Windows & macOS, no TUI — built on the OpenCode harness and adapted to be MiMo-first. Adds native multimodal understanding (image, PDF, video) plus voice dictation (ASR) and speech synthesis (TTS), with cost-aware model selection.
+homepage: https://shin4.github.io/mimo-code/
+tags:
+  - desktop
+  - gui
+  - opencode
+  - multimodal
+  - voice
+  - asr
+  - tts
+  - mimo


### PR DESCRIPTION
Adds **MiMo-Code** to PROJECTS — a native Windows & macOS desktop coding agent (no TUI) for the MiMo model family, built on the OpenCode harness and adapted to be MiMo-first: multimodal (image/PDF/video) + voice (ASR/TTS), with cost-aware model selection.

- ✅ Directly related to OpenCode (built on the OpenCode harness, keeps `@opencode-ai/*` SDK compatibility)
- ✅ Public · ✅ Actively maintained · ✅ Not a duplicate

Repo: https://github.com/shin4/mimo-code · Homepage: https://shin4.github.io/mimo-code/