### PR TITLE
Add handoff — cross-agent task dispatcher for Claude Code / Codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -731,6 +731,14 @@
     <br><br>
     <a href="https://github.com/Cluster444/agentic">🔗 <b>View Repository</b></a>
   </blockquote>
+<details>
+  <summary><b>handoff</b> <img src="https://badgen.net/github/stars/dazuiba/handoff" height="14"/> - <i>Delegate tasks to OpenCode / DeepSeek V4 right inside your Claude Code / Codex sessions.</i></summary>
+  <blockquote>
+    Cross-agent task dispatcher — hand off work to DeepSeek V4 (via OpenCode), Codex, or Claude Opus without leaving your current session. Runs in the background; result comes back automatically.
+    <br><br>
+    <a href="https://github.com/dazuiba/handoff">🔗 <b>View Repository</b></a>
+  </blockquote>
+</details>
 </details>
 
 <details>


### PR DESCRIPTION
## What is handoff?

[handoff](https://github.com/dazuiba/handoff) is a skill/subagent (backed by handoff-cli) that lets you delegate tasks to DeepSeek V4, Codex, or Claude Opus right inside your Claude Code / Codex session — without switching tools or losing context.

- Runs the delegated task in the background; your session never blocks
- Result comes back automatically when the task finishes
- Supports parallel tasks and resuming past sessions

## Why it belongs here

handoff lets Claude Code / Codex users delegate tasks to OpenCode's DeepSeek V4 backend, making it a direct complement to the OpenCode ecosystem.

## Links

- GitHub: https://github.com/dazuiba/handoff
- Install: `uv tool install handoff-cli && handoff init`
