### PR TITLE
docs: add opencode-skill-stats, opencode-hermes, opencode-auto-ocr-image

### DIFF
--- a/data/plugins/opencode-auto-ocr-image.yaml
+++ b/data/plugins/opencode-auto-ocr-image.yaml
@@ -1,0 +1,9 @@
+name: Opencode Auto OCR Image
+repo: https://github.com/Vcza5/opencode-auto-ocr-image
+tagline: Intelligent image handler — keeps FileParts for multimodal models, auto-OCR for text-only
+description: Intercepts pasted images and PDFs in OpenCode chat. For multimodal models (GPT-5, Claude 4, Gemini 3, etc.) it preserves the native FilePart so the model sees the image directly. For text-only models it runs built-in OCR via tesseract.js (auto-downloads language data on first use, zero system dependencies). Features !test-ocr diagnostic command and env-var language override.
+tags:
+  - ocr
+  - multimodal
+  - vision
+  - image

--- a/data/plugins/opencode-hermes.yaml
+++ b/data/plugins/opencode-hermes.yaml
@@ -1,0 +1,9 @@
+name: Opencode Hermes
+repo: https://github.com/Vcza5/opencode-hermes
+tagline: Progressive-disclosure reflector that auto-discovers patterns and generates skills
+description: Automatically analyzes OpenCode conversations to discover reusable workflows, domain knowledge, and behavioral patterns. Uses a two-pass AI analysis (lightweight scan then deep extraction) to generate SKILL.md files and rules. Features manual (/reflect) and weekly batch modes. All proposals go to a staging directory for human review — never auto-installs.
+tags:
+  - knowledge-management
+  - reflection
+  - automation
+  - skill-generation

--- a/data/plugins/opencode-skill-stats.yaml
+++ b/data/plugins/opencode-skill-stats.yaml
@@ -1,0 +1,8 @@
+name: Opencode Skill Stats
+repo: https://github.com/Vcza5/opencode-skill-stats
+tagline: Track skill invocation frequency with ASCII bar charts
+description: Track and visualize every skill() call across your OpenCode sessions. Features flexible time windows (today/week/month/all/last:Nd), auto-discovery of installed skills, removal detection for deleted skills, and zero-config operation. Data persisted to rolling JSONL log with auto-trim.
+tags:
+  - statistics
+  - monitoring
+  - telemetry


### PR DESCRIPTION

Three OpenCode plugins:

### opencode-skill-stats
Track and visualize skill invocation frequency across OpenCode sessions. Features ASCII bar charts, flexible time windows, auto-discovery of installed skills, and removal detection. Zero-config operation.

### opencode-hermes
Progressive-disclosure reflector that automatically analyzes conversations to discover reusable patterns, workflows, and knowledge. Generates SKILL.md files and rules via two-pass AI analysis. Manual (/reflect) and weekly batch modes.

### opencode-auto-ocr-image
Intelligent image/PDF handler. Preserves native FileParts for multimodal models, auto-OCR via tesseract.js for text-only models. Zero system dependencies — language data auto-downloads on first use.
