### PR TITLE
docs: add OpenCode rotator projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,15 @@
 </details>
 
 <details>
+  <summary><b>OpenCode Rotator Plugin</b> <img src="https://badgen.net/github/stars/xnnnc/opencode-rotator-plugin" height="14"/> - <i>TUI sidebar for a local ChatGPT account rotator server</i></summary>
+  <blockquote>
+    OpenCode TUI sidebar plugin that shows active account, Codex usage windows, watch status, and quick actions from a running local ChatGPT account rotator server.
+    <br><br>
+    <a href="https://github.com/xnnnc/opencode-rotator-plugin">🔗 <b>View Repository</b></a>
+  </blockquote>
+</details>
+
+<details>
   <summary><b>Opencode Sessions</b> <img src="https://badgen.net/github/stars/malhashemi/opencode-sessions" height="14"/> - <i>Session management</i></summary>
   <blockquote>
     Session management plugin for OpenCode with multi-agent collaboration support.
@@ -1053,6 +1062,15 @@ Also available for bat and Ghostty in the same repository.
     MCP server that exports OpenCode chat history to Markdown files with tool calls, reasoning, and cost summaries. Export current session, specific sessions by ID, or bulk exports. pip installable.
     <br><br>
     <a href="https://github.com/jjserenity/opencode-chat-export">🔗 <b>View Repository</b></a>
+  </blockquote>
+</details>
+
+<details>
+  <summary><b>OpenCode ChatGPT Account Rotator</b> <img src="https://badgen.net/github/stars/xnnnc/opencode-chatgpt-account-rotator" height="14"/> - <i>Local ChatGPT account rotation and usage checks for OpenCode</i></summary>
+  <blockquote>
+    Local GUI and CLI for OpenCode users who sign in with ChatGPT and manage more than one local account on one trusted machine. It saves local auth entries, checks usage, switches accounts, and pairs with an OpenCode TUI sidebar plugin.
+    <br><br>
+    <a href="https://github.com/xnnnc/opencode-chatgpt-account-rotator">🔗 <b>View Repository</b></a>
   </blockquote>
 </details>
 

--- a/data/plugins/opencode-rotator-plugin.yaml
+++ b/data/plugins/opencode-rotator-plugin.yaml
@@ -1,0 +1,13 @@
+name: OpenCode Rotator Plugin
+repo: https://github.com/xnnnc/opencode-rotator-plugin
+tagline: TUI sidebar for a local ChatGPT account rotator server
+description: OpenCode TUI sidebar plugin that shows active account, Codex usage windows, watch status, and quick actions from a running local ChatGPT account rotator server.
+scope:
+  - global
+  - project
+tags:
+  - tui
+  - chatgpt
+  - account-rotator
+  - local-tool
+homepage: https://github.com/xnnnc/opencode-rotator-plugin#readme

--- a/data/projects/opencode-chatgpt-account-rotator.yaml
+++ b/data/projects/opencode-chatgpt-account-rotator.yaml
@@ -1,0 +1,10 @@
+name: OpenCode ChatGPT Account Rotator
+repo: https://github.com/xnnnc/opencode-chatgpt-account-rotator
+tagline: Local ChatGPT account rotation and usage checks for OpenCode
+description: Local GUI and CLI for OpenCode users who sign in with ChatGPT and manage more than one local account on one trusted machine. It saves local auth entries, checks usage, switches accounts, and pairs with an OpenCode TUI sidebar plugin.
+tags:
+  - chatgpt
+  - account-rotator
+  - gui
+  - local-tool
+homepage: https://github.com/xnnnc/opencode-chatgpt-account-rotator#readme


### PR DESCRIPTION
## Summary

Adds two public OpenCode rotator projects to the generated awesome-opencode catalogue:

- `opencode-rotator-plugin`: OpenCode TUI sidebar plugin for a local ChatGPT account rotator server.
- `opencode-chatgpt-account-rotator`: companion local GUI/CLI for rotating saved OpenCode ChatGPT auth entries on one trusted machine.

## Why this fits

These projects are OpenCode-specific workflow tools. The plugin integrates with OpenCode's TUI/plugin surface, while the companion app provides the local account state and actions shown in the sidebar.

## Files changed

- Added `data/plugins/opencode-rotator-plugin.yaml`.
- Added `data/projects/opencode-chatgpt-account-rotator.yaml`.
- Regenerated `README.md` from the catalogue data.

## Verification

- Ran `npm run generate`.
- Ran `git diff --cached --check` before commit.

## Notes

The root rotator app handles sensitive local auth state and is documented as local-only for one trusted user on one trusted machine. The plugin is only a client for the local rotator server and does not read or write auth files directly.