### PR TITLE
docs: add CLAUDE.md for opencode to plugins

### DIFF
--- a/data/plugins/opencode-claude-md.yaml
+++ b/data/plugins/opencode-claude-md.yaml
@@ -1,0 +1,4 @@
+name: CLAUDE.md for opencode
+repo: https://github.com/uwuclxdy/opencode-claude-md
+tagline: Full CLAUDE.md hierarchy, the way Claude Code loads it
+description: Loads CLAUDE.md files the way Claude Code does, the full ancestor hierarchy, CLAUDE.local.md, @path imports, managed policy files, and subdirectory files attached lazily as tools touch them. Skips whatever opencode's native instruction loader already picked up so nothing reaches the model twice.


### PR DESCRIPTION
Adds `data/plugins/opencode-claude-md.yaml`.

[**opencode-claude-md**](https://github.com/uwuclxdy/opencode-claude-md) loads CLAUDE.md files the way Claude Code does: the full ancestor hierarchy, `CLAUDE.local.md`, `@path` imports, managed policy files, and subdirectory files attached lazily as tools touch them. It skips whatever opencode's native instruction loader already picked up, so nothing reaches the model twice.

### Checklist
- [x] **Relevant**: opencode plugin (`@opencode-ai/plugin`), published on npm as `opencode-claude-md`
- [x] **Public**: MIT, source at the repo above
- [x] **Maintained**: active, last commit this week
- [x] **Unique**: no existing CLAUDE.md-hierarchy entry in `data/plugins/`
- [x] **Complete**: `name`, `repo`, `tagline` (53 chars), `description`; passes `node scripts/validate.js`