### PR TITLE
docs: add opencode-token-counter to plugins

### DIFF
--- a/data/plugins/opencode-token-counter.yaml
+++ b/data/plugins/opencode-token-counter.yaml
@@ -1,0 +1,4 @@
+name: Opencode Token Counter
+repo: https://github.com/coldhell7/Opencode-token-counter
+tagline: Automatic token usage, cost, and provider statistics tracking
+description: "Automatically tracks token usage, cost, and provider/model statistics across all your OpenCode AI sessions. Features in-chat usage reports, interactive Chart.js dashboard, CSV export, and configurable time ranges (24h / 7d / 30d / 1y)."


### PR DESCRIPTION
## Description

Adds [opencode-token-counter](https://github.com/coldhell7/Opencode-token-counter) to the plugins list — an OpenCode plugin that automatically tracks token usage, cost, and provider/model statistics across all AI sessions.

**Features:**
- Automatic token, cost, and provider/model tracking
- In-chat usage reports (24h / 7d / 30d)
- Interactive Chart.js web dashboard
- CSV export
- SQLite-backed, append-only storage

## Checklist
- [x] Relevant — Directly related to OpenCode
- [x] Public — Repository is publicly accessible
- [x] Maintained — Active commits within the last 6 months
- [x] Unique — Not a duplicate of existing entry
- [x] Complete — All required fields included