### PR TITLE
docs: add opencode-sessions-explorer to plugins

### DIFF
--- a/data/plugins/opencode-sessions-explorer.yaml
+++ b/data/plugins/opencode-sessions-explorer.yaml
@@ -1,0 +1,4 @@
+name: OpenCode Sessions Explorer
+repo: https://github.com/iamironz/opencode-sessions-explorer
+tagline: Search, recall, grep, and cost-analyze every past OpenCode session
+description: "Ask your agent: What did I work on last week? How much did that session cost? Where did this error happen before? Which tools failed most? Exposes the local OpenCode SQLite database as 18 LLM-callable tools for session recall, full-text search, grep, cost/usage analysis, tool-failure analysis, and session unarchiving."


### PR DESCRIPTION
## Submission Type

- [x] Plugin
- [ ] Project
- [ ] Theme
- [ ] Agent
- [ ] Resource

## Details

**Name:** OpenCode Sessions Explorer  
**Repository:** https://github.com/iamironz/opencode-sessions-explorer  
**Tagline:** Search, recall, grep, and cost-analyze every past OpenCode session

Exposes the local OpenCode SQLite session database as 18 LLM-callable tools for session recall, full-text search, grep, cost/usage analysis, tool-failure analysis, and session unarchiving. Published on npm as `opencode-sessions-explorer@0.1.2` with provenance.

Not to be confused with `opencode-sessions` (a different, simpler package by a different author).

## Checklist

- [x] Relevant to OpenCode
- [x] Repository is public and accessible
- [x] Actively maintained
- [x] Not a duplicate
- [x] YAML file in correct folder (`data/plugins/`)
- [x] Filename is kebab-case (`opencode-sessions-explorer.yaml`)
