### PR TITLE
docs: add AIDevOps to plugins

### DIFF
--- a/data/plugins/aidevops.yaml
+++ b/data/plugins/aidevops.yaml
@@ -1,0 +1,5 @@
+name: AIDevOps
+repo: https://github.com/marcusquinn/aidevops
+homepage: https://aidevops.sh
+tagline: AI DevOps framework and OpenCode plugin
+description: OpenCode-first AI DevOps framework with agents, skills, workflows, safety hooks, memory, GitHub worker dispatch, and integrations for code, infrastructure, content, SEO, and operations.


### PR DESCRIPTION
## Submission Type

- [x] Plugin
- [ ] Project
- [ ] Theme
- [ ] Agent
- [ ] Resource

## Details

**Name:** AIDevOps
**Repository:** https://github.com/marcusquinn/aidevops
**Website:** https://aidevops.sh
**Tagline:** AI DevOps framework and OpenCode plugin

## Summary

Adds AIDevOps to the plugin list as an OpenCode-first AI DevOps framework with agents, skills, workflows, safety hooks, memory, GitHub worker dispatch, and integrations for code, infrastructure, content, SEO, and operations.

Resolves #430.

## Checklist

- [x] Relevant to OpenCode
- [x] Repository is public and accessible
- [x] Actively maintained
- [x] Not a duplicate
- [x] YAML file in correct folder (`data/plugins/`)
- [x] Filename is kebab-case (`aidevops.yaml`)

## Verification

- `npm ci --ignore-scripts && npm run validate`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.59 plugin for [OpenCode](https://opencode.ai) v1.17.4 with gpt-5.5 spent 3m and 65,705 tokens on this with the user in an interactive session.
