### PR TITLE
feat(plugins): add Antigravity CLI Auth plugin

### DIFF
--- a/data/plugins/agy-auth.yaml
+++ b/data/plugins/agy-auth.yaml
@@ -1,0 +1,4 @@
+name: OpenCode Antigravity CLI Auth
+repo: https://github.com/anthonyhaussman/opencode-agy-auth
+tagline: Google Antigravity account auth
+description: Authenticate the Opencode CLI with your Google account so you can use your existing Antigravity plan.

--- a/dist/registry.json
+++ b/dist/registry.json
@@ -252,6 +252,18 @@
     "tags": []
   },
   {
+    "productId": "antigravity-auth",
+    "type": "plugins",
+    "displayName": "Antigravity Auth",
+    "repoUrl": "https://github.com/anthonyhaussman/opencode-agy-auth",
+    "tagline": "Google Antigravity account auth",
+    "description": "Authenticate the Opencode CLI with your Google account so you can use your existing Antigravity plan.",
+    "scope": [
+      "global"
+    ],
+    "tags": []
+  },
+  {
     "productId": "google-ai-search",
     "type": "plugins",
     "displayName": "Google AI Search",


### PR DESCRIPTION
Add configuration for the OpenCode Antigravity CLI Auth plugin to the registry.
This enables authentication with Google accounts for users to leverage their existing Antigravity plans.

## Submission Type

- [x] Plugin
- [ ] Project
- [ ] Theme
- [ ] Agent
- [ ] Resource

## Details

**Name:** OpenCode Antigravity CLI Auth Plugin
**Repository:** https://github.com/anthonyhaussman/opencode-agy-auth
**Tagline:** Google Antigravity account auth

## Checklist

- [x] Relevant to OpenCode
- [x] Repository is public and accessible
- [x] Actively maintained
- [x] Not a duplicate
- [x] YAML file in correct folder (`data/{category}/`)
- [x] Filename is kebab-case (e.g., `my-plugin.yaml`)