### PR TITLE
Add AccInt plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,15 @@
 <br>
 
 <details>
+  <summary><b>AccInt</b> <img src="https://badgen.net/github/stars/maxbaluev/accreted-intelligence" height="14"/> - <i>Local Work Model memory for OpenCode agents</i></summary>
+  <blockquote>
+    Accreted scored memory for OpenCode sessions with MCP retrieval and action verbs, lifecycle hooks, and cross-project acc.db continuity for agent work.
+    <br><br>
+    <a href="https://github.com/maxbaluev/accreted-intelligence">🔗 <b>View Repository</b></a>
+  </blockquote>
+</details>
+
+<details>
   <summary><b>Agent Identity</b> <img src="https://badgen.net/github/stars/gotgenes/opencode-agent-identity" height="14"/> - <i>Agent self-identity and per-message attribution for multi-agent sessions</i></summary>
   <blockquote>
     Two plugins that improve agent identity awareness. AgentSelfIdentityPlugin injects a one-liner into the system prompt so the model knows which agent it's operating as. AgentAttributionToolPlugin exposes a tool for querying per-message agent attribution via the SDK, useful for agents that review multi-agent sessions.

--- a/data/plugins/accint.yaml
+++ b/data/plugins/accint.yaml
@@ -1,0 +1,4 @@
+name: AccInt
+repo: https://github.com/maxbaluev/accreted-intelligence
+tagline: Local Work Model memory for OpenCode agents
+description: Accreted scored memory for OpenCode sessions with MCP retrieval and action verbs, lifecycle hooks, and cross-project acc.db continuity for agent work.


### PR DESCRIPTION
## Summary
- Add AccInt to the OpenCode plugins catalogue via `data/plugins/accint.yaml`.
- Regenerate `README.md` from the YAML source data.

## Validation
- `npm ci`
- `npm run validate`
- `npm run generate`
- `git diff --check`

Note: `npm ci` reports existing npm audit findings in the repo dependencies; the catalogue validation and README generation both pass.