### PR TITLE
Add AION — time-series harness plugin

### DIFF
--- a/data/plugins/aion.yaml
+++ b/data/plugins/aion.yaml
@@ -1,0 +1,17 @@
+name: AION
+repo: https://github.com/ztxtech/aion
+tagline: Time-series harness with multi-agent review, skills, tools, and hooks
+description: A compiled TypeScript OpenCode plugin that turns OpenCode into a time-series research harness. Bundles six specialized agents (orchestrator, requirements analyst, information collector, coder, and two critic roles), seventeen skills, twenty-plus tools, and eight coordination protocols into one self-contained bundle installed via a one-command CLI. Enforces a four-layer model (task, workspace, execution, review) with hard gates for data-leakage detection, ablation-backed statistical rigor, and dual-critic governance before any output ships.
+homepage: https://github.com/ztxtech/aion
+scope:
+  - project
+min_version: 0.9.0
+tags:
+  - agents
+  - time-series
+  - research
+  - review
+  - governance
+  - skills
+  - tools
+  - multi-agent


### PR DESCRIPTION
Adds [`AION`](https://github.com/ztxtech/aion) to the **Plugins** category via `data/plugins/aion.yaml`.

## What is AION?

AION is a compiled TypeScript OpenCode plugin that turns OpenCode into a time-series research harness. Installed through a one-command CLI (`aion-ts init .`), it drops a self-contained bundle into `.opencode/plugins/` and bundles:

- **6 agents** — orchestrator + requirements analyst, information collector, coder, and two critic roles (dual-review governance)
- **17 skills** — workspace init, planning, time-series review, safety gate, etc.
- **20+ tools** — experiment runners, governance gates, memory sync, Hugging Face dataset CLI, leakage checks
- **8 protocols** — dispatch, report-back, rebuttal, stop-go, lifecycle, memory-sync, runtime-events, compaction

It enforces a four-layer model (task → workspace → execution → review) with hard gates for data-leakage detection and ablation-backed statistical rigor.

## Entry Requirements

- [x] **Relevant** — AION is a native OpenCode TypeScript plugin (auto-discovered in `.opencode/plugins/`).
- [x] **Public** — https://github.com/ztxtech/aion is publicly accessible.
- [x] **Maintained** — active development; the compiled-plugin release shipped 2026-06-14.
- [x] **Unique** — no existing entry for AION (confirmed against `data/plugins/`).
- [x] **Complete** — all required fields (`name`, `repo`, `tagline` ≤ 120 chars, `description`) plus optional `scope`, `tags`, `min_version`, `homepage`.

## Why Plugins?

AION is a plugin/extension that augments OpenCode itself (loaded from `.opencode/plugins/`), so it belongs in **Plugins** rather than Agents (standalone agent configs) or Projects (external tools/GUIs). README will regenerate from this YAML automatically.