### PR TITLE
docs: add magic-context to plugins

### DIFF
--- a/data/plugins/magic-context.yaml
+++ b/data/plugins/magic-context.yaml
@@ -1,0 +1,4 @@
+name: Magic Context
+repo: https://github.com/cortexkit/magic-context
+tagline: Unbounded context and self-managing memory for one lifelong session
+description: The hippocampus for coding agents. A background historian compresses old history into tiered compartments so sessions run with no compaction pauses, while lifting durable knowledge into cross-session project memory. An overnight dreamer consolidates, verifies, and prunes memories, and the agent can recall across memories, past conversations, and git history on demand.


### PR DESCRIPTION
Adds Magic Context to the plugins list.

It's a context-management and memory plugin for OpenCode. A background historian compresses old history into tiered compartments so sessions keep running without compaction pauses, and in the same pass it lifts durable facts (decisions, constraints, conventions) into cross-session project memory. There's also an optional overnight dreamer that consolidates and prunes memories, plus `ctx_search`/`ctx_expand` for recall across memories, past conversations, and git history.

Checklist:
- Relevant to OpenCode (ships an `@cortexkit/opencode-magic-context` plugin)
- Public repo
- Actively maintained (latest release v0.24.1, Jun 2026)
- Not a duplicate
- All required fields included

`node scripts/validate.js data/plugins/magic-context.yaml` passes locally.
