### PR TITLE
docs: add opencode-smartsnip to plugins

### DIFF
--- a/data/plugins/opencode-smartsnip.yaml
+++ b/data/plugins/opencode-smartsnip.yaml
@@ -1,0 +1,4 @@
+name: OpenCode SmartSnip
+repo: https://github.com/carson2222/opencode-smartsnip
+tagline: Cuts shell-output tokens safely by wrapping only commands snip can filter.
+description: An OpenCode plugin that routes shell commands through snip only when filtering is safe, reducing context usage without breaking pipes, quotes, redirects, heredocs, or raw API output.


### PR DESCRIPTION
## Summary
Adds `OpenCode SmartSnip` to the Awesome OpenCode plugins list.

## Why
`opencode-smartsnip` is a public, actively maintained OpenCode plugin focused on reducing shell-output token usage safely by only routing commands through `snip` when filtering will not break command behavior.
