### PR TITLE
docs: add opencode-smartsnip to plugins

### DIFF
--- a/data/plugins/opencode-smartsnip.yaml
+++ b/data/plugins/opencode-smartsnip.yaml
@@ -1,0 +1,12 @@
+name: opencode-smartsnip
+repo: https://github.com/carson2222/opencode-smartsnip
+tagline: Cut shell-output tokens by safely wrapping commands with snip
+description: Reduces shell-output tokens in opencode by routing each bash command through snip's filters, wrapping only the segments that are safe to filter and leaving everything else byte-identical. Cuts git/test/build noise (~70% on git output) without breaking pipes, heredocs, subshells, or chained commands. Validated against 23k+ real bash commands.
+scope:
+  - global
+  - project
+tags:
+  - tokens
+  - context
+  - snip
+  - shell


### PR DESCRIPTION
Adds **opencode-smartsnip** to the plugins category.

It cuts shell-output tokens in opencode by routing each bash command through [snip](https://github.com/edouard-claude/snip)'s filters, wrapping only the segments that are safe to filter and leaving everything else byte-identical (no `snip snip` stacking, broken pipes, heredocs, or truncated API responses).

- Repo: https://github.com/carson2222/opencode-smartsnip
- npm: https://www.npmjs.com/package/opencode-smartsnip
- License: MIT

### Entry requirements
- [x] **Relevant** — OpenCode plugin
- [x] **Public** — repo is public
- [x] **Maintained** — active commits
- [x] **Unique** — not already listed
- [x] **Complete** — name, repo, tagline, description (plus scope + tags)