### PR TITLE
docs: add basemind to plugins

### DIFF
--- a/data/plugins/basemind.yaml
+++ b/data/plugins/basemind.yaml
@@ -1,0 +1,13 @@
+name: basemind
+repo: https://github.com/Goldziher/basemind
+tagline: Full AI context layer over MCP — code-map, document RAG, agent memory, web crawl, git history
+description: >-
+  Full AI context layer over MCP — tree-sitter code-map, document RAG, shared
+  agent memory, web crawl, and git history. 300+ languages. Published to npm as
+  basemind-opencode (https://www.npmjs.com/package/basemind-opencode).
+installation: |
+  Add to your `opencode.json`:
+
+  ```json
+  { "plugin": ["basemind-opencode@latest"] }
+  ```


### PR DESCRIPTION
Adds **basemind** to the plugins list.

- **npm**: `basemind-opencode` (https://www.npmjs.com/package/basemind-opencode), latest `0.2.0`
- **Repo**: https://github.com/Goldziher/basemind
- **Install**: `{ "plugin": ["basemind-opencode@latest"] }` in `opencode.json`

basemind is a full AI context layer over MCP — tree-sitter code-map, document RAG, shared agent memory, web crawl, and git history, across 300+ languages.

Added `data/plugins/basemind.yaml` only; the README regenerates from YAML per contributing.md. Validated locally with `node scripts/validate.js` (all files pass).