### PR TITLE
Add ax project

### DIFF
--- a/data/projects/ax.yaml
+++ b/data/projects/ax.yaml
@@ -1,0 +1,4 @@
+name: ax
+repo: https://github.com/Necmttn/ax
+tagline: Local telemetry graph for AI coding agents
+description: Local-first telemetry and taste graph for AI coding agents. Ingests OpenCode, Claude Code, Codex, Cursor, and Pi session data plus OTLP, then exposes recall, cost, skill/hook usage, churn, and workflow-extraction views through a CLI, dashboard, and MCP server.


### PR DESCRIPTION
Adds ax as a project entry. ax is relevant to OpenCode users because it ingests OpenCode session data alongside Claude Code, Codex, Cursor, and Pi, then exposes local recall, cost, skill/hook usage, churn, and workflow-extraction views through a CLI, dashboard, and MCP server.

Validation:
- `npm run validate`
- `git diff --check`

Note: `npm ci` reported existing npm audit findings in the dependency tree; this PR does not change dependencies.

---

_Generated with [ax](https://github.com/Necmttn/ax)._