### PR TITLE
docs: add LoopTroop to projects

### DIFF
--- a/data/projects/looptroop.yaml
+++ b/data/projects/looptroop.yaml
@@ -1,0 +1,14 @@
+name: LoopTroop
+repo: https://github.com/looptroop-ai/LoopTroop
+tagline: Local GUI orchestrator for autonomous AI coding using multi-model planning councils and isolated worktrees
+description: Local-first, open-source GUI orchestrator that runs long-running AI coding
+  tickets end-to-end. An LLM Council plans the work, tasks are decomposed into atomic
+  units (Beads) executed in isolated git worktrees, and a Ralph Loop recovers from
+  errors with a fresh context. Built on OpenCode.
+homepage: https://www.looptroop.ovh/
+tags:
+  - orchestration
+  - multi-agent
+  - context-engineering
+  - local-first
+  - opencode


### PR DESCRIPTION
## What

Adds **LoopTroop** to the Projects list.

`data/projects/looptroop.yaml` — single new entry. README left untouched (auto-regenerates from YAML via CI).

## Why

LoopTroop is a local-first, open-source GUI orchestrator built on OpenCode that runs long-running AI coding tickets end-to-end:

- An **LLM Council** plans the work (multiple model instances draft, score, and vote on a plan).
- Work is decomposed into atomic units (**Beads**) executed in isolated git worktrees.
- A **Ralph Loop** recovers from errors with a fresh context to avoid context pollution.
- Final changes ship back to the main branch via OpenCode worktrees.

## Eligibility

- ✅ **Relevant** — built directly on OpenCode (its tagline/description state this explicitly).
- ✅ **Public** — https://github.com/looptroop-ai/LoopTroop (MIT).
- ✅ **Maintained** — active commits, latest push today.
- ✅ **Unique** — no existing entry; not a duplicate.
- ✅ **Complete** — all required fields (`name`, `repo`, `tagline`, `description`) included; `homepage` + `tags` added for downstream metadata.

Happy to adjust wording, tags, or the category if a maintainer feels Projects isn't the best fit (vs. Agents).
