### PR TITLE
docs: add agent-historian to projects

### DIFF
--- a/data/projects/agent-historian.yaml
+++ b/data/projects/agent-historian.yaml
@@ -1,0 +1,4 @@
+name: agent-historian
+repo: https://github.com/adlternative/agent-historian
+tagline: Search and read past AI coding-agent sessions from the CLI
+description: A read-only CLI (ochist) plus an Agent Skill so OpenCode and other agents can search and re-read their own past conversation history before redoing research. Reads transcripts the agents already persist locally — no memory layer, embeddings, index, daemon, or network. Project- or global-scoped, subagent-aware, zero runtime dependencies.


### PR DESCRIPTION
Adds **agent-historian** under `data/projects/`.

[agent-historian](https://github.com/adlternative/agent-historian) is a read-only CLI (`ochist`) plus an Agent Skill that lets OpenCode (and other locally detected agents) search and re-read their own past conversation history before redoing research.

- Reads OpenCode's `opencode.db` (and other agents' transcripts) directly — no memory layer, embeddings, index, daemon, or network calls.
- Project- or global-scoped search; subagent-aware; zero runtime dependencies (Node's built-in `node:sqlite`).

Entry requirements:
- [x] Relevant — directly supports OpenCode
- [x] Public repository
- [x] Maintained — active commits
- [x] Unique — no duplicate
- [x] Complete — name, repo, tagline, description