### PR TITLE
docs: add aware-code to agents

### DIFF
--- a/data/agents/aware-code.yaml
+++ b/data/agents/aware-code.yaml
@@ -1,0 +1,4 @@
+name: AwareCode
+repo: https://github.com/Wudi12317/aware-code
+tagline: Documentation-aware coding protocol for OpenCode
+description: A 5-phase meta-skill that enforces documentation-first coding. Scans project docs before writing code, remembers root causes of errors, reviews code quality and security, synchronizes docs after changes, and outputs structured summaries. Designed for OpenCode's skill system.


### PR DESCRIPTION
This PR adds [AwareCode](https://github.com/Wudi12317/aware-code) to the agents list ? a documentation-aware coding meta-skill for OpenCode that enforces context-first protocols, error memory, quality review, and doc synchronization.