### PR TITLE
docs: add opencode-thinking-fix to plugins

### DIFF
--- a/data/plugins/opencode-thinking-fix.yaml
+++ b/data/plugins/opencode-thinking-fix.yaml
@@ -1,0 +1,14 @@
+name: opencode-thinking-fix
+repo: https://github.com/tbosancheros39/opencode-thinking-fix
+tagline: Fixes reasoning_content 400 errors for reasoning models in OpenCode
+description: Plugin+proxy combo that eliminates reasoning_content 400 errors when OpenCode strips chain-of-thought from multi-turn conversations. Supports DeepSeek, Kimi, GLM, MiMo and MiniMax with model-aware echo logic — injecting empty strings, spaces or full CoT as each model requires. Zero-dependency proxy captures reasoning from SSE streams and replays it on subsequent turns; all 7 tested models verified working on multi-turn.
+homepage: https://www.npmjs.com/package/opencode-thinking-fix
+installation: npm i opencode-thinking-fix
+tags:
+  - reasoning
+  - deepseek
+  - kimi
+  - glm
+  - minimax
+  - mimo
+  - proxy


### PR DESCRIPTION
## Summary

Adds [opencode-thinking-fix](https://github.com/tbosancheros39/opencode-thinking-fix) to the plugins list.

## What it does

Fixes `reasoning_content` 400 errors for DeepSeek, Kimi, GLM, MiMo, and MiniMax reasoning models in OpenCode. These models require their chain-of-thought (`reasoning_content`) to be echoed back on multi-turn conversations — OpenCode strips it, causing HTTP 400 errors on turn 2+.

### Architecture
- **Plugin**: Self-detection via message scanning — injects missing `reasoning_content` with model-appropriate values
- **Proxy** (Node.js, zero deps): SSE reasoning cache that captures and replays chain-of-thought across turns

### Key facts
- v1.1.9 published on npm (12 versions)
- CI pipeline green (GitHub Actions, 46 tests)
- 7/7 models verified working on multi-turn
- Zero npm dependencies for proxy
- Fixes ecosystem-wide bug affecting 30+ projects

## Checklist
- [x] Repository is public
- [x] Active commits (latest: today)
- [x] Directly related to OpenCode
- [x] Not a duplicate of existing entry
- [x] All required fields included
- [x] YAML matches schema (`data/schema.json`)