### PR TITLE
Add agentcairn (local-first memory plugin)

### DIFF
--- a/data/plugins/agentcairn.yaml
+++ b/data/plugins/agentcairn.yaml
@@ -1,0 +1,4 @@
+name: agentcairn
+repo: https://github.com/ccf/agentcairn
+tagline: Local-first memory — your agent's memory as plain Markdown in an Obsidian vault you own.
+description: A native OpenCode plugin (recall-at-start + capture-at-end) backed by agentcairn. Memories live as plain-Markdown notes in an Obsidian vault you can read, edit, and grep, with hybrid BM25 + vector + graph recall — shared across Claude Code, Codex, Cursor, and Hermes. Local-first, secret-redacted; install with `cairn install opencode`.


### PR DESCRIPTION
Adds **agentcairn** — a native OpenCode plugin that gives your agent persistent, local-first memory.

- **Recall-at-start + capture-at-end** as a thin shell over the `cairn` CLI (memory logic stays in Python).
- Memories are **plain-Markdown notes in an Obsidian vault you own** — readable, editable, greppable — with hybrid BM25 + vector + graph recall.
- Shared across **Claude Code, Codex, Cursor, and Hermes** too; local-first + secret-redacted.
- One-command install: `cairn install opencode` (writes the MCP server, slash commands, and the ambient plugin).

Verified end-to-end on OpenCode 1.17.5 (MCP `recall`/`remember` tools + ambient session capture).