### PR TITLE
docs: add specralph to projects

### DIFF
--- a/data/projects/specralph.yaml
+++ b/data/projects/specralph.yaml
@@ -1,0 +1,5 @@
+name: SpecRalph
+repo: https://github.com/iyaki/specralph
+tagline: Spec-Driven Ralph-Wiggum AI coding automation CLI
+description: AI Loops runner for OpenCode and other agent CLIs.
+  Enables spec-driven development workflows with structured prompt engineering and loop automation for AI coding agents.


### PR DESCRIPTION
Adds [SpecRalph](https://github.com/iyaki/specralph), a spec-driven AI coding automation CLI that runs AI loops for  OpenCode and other agent CLIs.

What it does:
                                                                                                                                              
- Enables spec-driven development workflows                                                                                                                   
- Provides structured prompt engineering                                                                                                                      
- Automates loop (ralph-wiggum style)  execution for AI coding agents

## Submission Type

- [ ] Plugin
- [x] Project
- [ ] Theme
- [ ] Agent
- [ ] Resource

## Details

**Name:** SpecRalph
**Repository:** https://github.com/iyaki/specralph
**Tagline:** Spec-Driven Ralph-Wiggum AI coding automation CLI

## Checklist

- [x] Relevant to OpenCode
- [x] Repository is public and accessible
- [x] Actively maintained
- [x] Not a duplicate
- [x] YAML file in correct folder (`data/{category}/`)
- [x] Filename is kebab-case (e.g., `my-plugin.yaml`)

## YAML Format

Create a file in `data/{category}/your-entry.yaml`:

```yaml
name: Your Entry Name
repo: https://github.com/owner/repo
tagline: Short punchy summary (shown in collapsed view)
description: Longer description explaining what it does.
```

See [contributing.md](contributing.md) for full instructions.
