### PR TITLE
docs(plugins): add Lens, Image Preview, and Voice plugins for OpenCode Web

### DIFF
--- a/data/plugins/opencode-lens-image-preview.yaml
+++ b/data/plugins/opencode-lens-image-preview.yaml
@@ -1,4 +1,4 @@
 name: Image Preview
 repo: https://github.com/Flickwire-Agent/opencode-lens-image-preview
-tagline: Inline image previews for OpenCode Web
-description: A Lens plugin that renders images inline in OpenCode Web chat. Supports markdown image syntax (\![alt](path)), remote URLs, and local file paths. Features click-to-expand, lazy loading, code block protection, and error fallbacks. Local files are served through the Lens proxy.
+tagline: Inline image previews from URLs in OpenCode Web
+description: A Lens plugin that renders images from URLs inline in OpenCode Web chat. Supports markdown image syntax (\![alt](url)) and raw image URLs. Features click-to-expand, lazy loading, code block protection, and error fallbacks.

--- a/data/plugins/opencode-lens-image-preview.yaml
+++ b/data/plugins/opencode-lens-image-preview.yaml
@@ -1,0 +1,4 @@
+name: Image Preview
+repo: https://github.com/Flickwire-Agent/opencode-lens-image-preview
+tagline: Inline image previews for OpenCode Web
+description: A Lens plugin that renders images inline in OpenCode Web chat. Supports markdown image syntax (\![alt](path)), remote URLs, and local file paths. Features click-to-expand, lazy loading, code block protection, and error fallbacks. Local files are served through the Lens proxy.

--- a/data/plugins/opencode-lens.yaml
+++ b/data/plugins/opencode-lens.yaml
@@ -1,0 +1,4 @@
+name: Lens
+repo: https://github.com/Flickwire-Agent/opencode-lens
+tagline: Plugin injection framework for OpenCode Web
+description: A local reverse proxy that loads web plugins and injects them into the OpenCode Web HTML response. Adds script injection, an integrated settings UI for toggling plugins, and a simple manifest format for building browser-side OpenCode Web plugins. Enables extending the OpenCode Web UI with custom JavaScript modules, HTML injection, and interactive controls.

--- a/data/plugins/opencode-web-voice-plugin.yaml
+++ b/data/plugins/opencode-web-voice-plugin.yaml
@@ -1,0 +1,4 @@
+name: OpenCode Web Voice Plugin
+repo: https://github.com/Flickwire-Agent/opencode-web-voice-plugin
+tagline: Voice input for OpenCode Web through Lens
+description: Adds a microphone button to the OpenCode Web prompt composer using the Web Speech API. Record speech, insert transcripts directly into the prompt editor, and send naturally. Requires Lens to load.


### PR DESCRIPTION
Adds three Lens-related plugins to the awesome-opencode registry:

**Lens** — A local reverse proxy and plugin injection framework for OpenCode Web.

**Image Preview** — A Lens plugin that renders generated images, screenshots, and local image files inline in OpenCode Web chat.

**OpenCode Web Voice Plugin** — A Lens plugin that adds a microphone button for voice input via the Web Speech API.