### PR TITLE
Add Claudescope to projects

### DIFF
--- a/data/projects/claudescope.yaml
+++ b/data/projects/claudescope.yaml
@@ -1,0 +1,4 @@
+name: Claudescope
+repo: https://github.com/vladar107/claudescope
+tagline: Local, read-only web UI to browse, search, and analyze OpenCode (and other agents') sessions
+description: Local-first CLI that serves a web UI to browse, read, search, and analyze AI coding-agent transcripts — OpenCode sessions alongside Claude Code, Codex, Junie, pi, and Copilot CLI. Sessions are merged by working directory; includes DuckDB full-text search and token-cost analytics. Read-only and cross-platform, distributed as a single npm package (MIT).


### PR DESCRIPTION
Adds a new project entry: `data/projects/claudescope.yaml` (README left untouched — it regenerates from YAML).

[Claudescope](https://github.com/vladar107/claudescope) is a local, read-only CLI (`claudescope start`) that serves a web UI to browse, read, search, and analyze AI coding-agent transcripts. It reads **OpenCode** sessions (from `opencode.db`) alongside Claude Code, Codex, Junie, pi, and Copilot CLI, merging them by working directory, with DuckDB full-text search and token-cost analytics. Single npm package, MIT, cross-platform.

It's a close peer to the existing `agenttrace` entry — a local session-inspection tool for OpenCode.

- [x] Public repository
- [x] All required fields included (name, repo, tagline ≤120 chars, description)