### PR TITLE
docs: add AI Agent Automations resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -2006,6 +2006,15 @@ template (cowork-with-github). Install: drag-and-drop .plugin into Cowork.
 <br>
 
 <details>
+  <summary><b>AI Agent Automations</b> <img src="https://badgen.net/github/stars/ChmaraX/ai-agent-automations" height="14"/> - <i>Automation prompts for OpenCode, Codex, Claude Code, and Cursor workflows</i></summary>
+  <blockquote>
+    A curated collection of agent automation prompts for real-world engineering and operations workflows. Covers OpenCode, Codex, Claude Code, and Cursor patterns for code maintenance, security reviews, research, support, billing, and work triage.
+    <br><br>
+    <a href="https://github.com/ChmaraX/ai-agent-automations">🔗 <b>View Repository</b></a>
+  </blockquote>
+</details>
+
+<details>
   <summary><b>Akephalos</b> <img src="https://badgen.net/github/stars/sunnja69/akephalos" height="14"/> - <i>Local-first markdown passport for portable agent context and memory</i></summary>
   <blockquote>
     A local-first, markdown-first `.akephalos` passport for portable agent preferences, tool notes, rules, project context, and durable memories. It uses plain files and Git so MCP-capable coding-agent workflows can inspect and carry context across tools and machines without hosted sync.

--- a/data/resources/ai-agent-automations.yaml
+++ b/data/resources/ai-agent-automations.yaml
@@ -1,0 +1,15 @@
+name: AI Agent Automations
+repo: https://github.com/ChmaraX/ai-agent-automations
+tagline: Automation prompts for OpenCode, Codex, Claude Code, and Cursor workflows
+description: A curated collection of agent automation prompts for real-world
+  engineering and operations workflows. Covers OpenCode, Codex, Claude Code,
+  and Cursor patterns for code maintenance, security reviews, research,
+  support, billing, and work triage.
+tags:
+  - automations
+  - prompts
+  - workflows
+  - codex
+  - claude-code
+  - cursor
+homepage: https://trigger.tools


### PR DESCRIPTION
## Summary
- add `AI Agent Automations` under `data/resources/`
- regenerate `README.md` to include the new rendered entry

## Why
This repository is a curated collection of agent automation prompts for real-world engineering and operations workflows.

- Repo: https://github.com/ChmaraX/ai-agent-automations
- Site: https://trigger.tools

## Category
This fits `data/resources/` best because it is a reusable prompt and automation library rather than an installable OpenCode plugin package or a standalone OpenCode application.

## Entry requirements
- [x] Relevant — reusable OpenCode-compatible automation prompts and workflows
- [x] Public — repository is publicly accessible
- [x] Maintained — active commits within the last 6 months
- [x] Unique — no existing entry for this repository
- [x] Complete — YAML includes the required fields and generated README entry

## Validation
- `npm run validate`
- `npm run generate`
