### PR TITLE
Add Roborev and djimitflo to Projects

### DIFF
--- a/data/projects/djimitflo.yaml
+++ b/data/projects/djimitflo.yaml
@@ -1,0 +1,10 @@
+name: djimitflo
+repo: https://github.com/djimit/djimitflo
+tagline: Djimit Agentic OS control plane with verified OpenCode executor integration
+description: A TypeScript monorepo control plane for goal-driven autonomous loops, governance gates, and multi-runtime execution. Includes a verified OpenCode executor runtime, loop lifecycle management, maker/checker/security leases, and a dashboard for tracking goals and loop runs.
+tags:
+  - agentic-os
+  - control-plane
+  - loops
+  - governance
+  - opencode

--- a/data/projects/roborev.yaml
+++ b/data/projects/roborev.yaml
@@ -1,0 +1,9 @@
+name: Roborev
+repo: https://github.com/kenn-io/roborev
+tagline: Background code review agent with OpenCode agent-hook support
+description: A multi-agent background commit-review tool that runs automated code reviews and exposes a $roborev-fix skill via OpenCode's agent hook. Useful for catching issues before they land while keeping the review loop inside the OpenCode workflow.
+tags:
+  - code-review
+  - background-agent
+  - git
+  - opencode


### PR DESCRIPTION
This PR adds two OpenCode-related projects to the awesome-opencode list:

- **Roborev** — background code review agent with OpenCode agent-hook support.
- **djimitflo** — Djimit Agentic OS control plane with verified OpenCode executor integration.

Both entries are placed under `data/projects/` as external tools/projects, not plugins or agents.