### PR TITLE
docs: add AionUi to projects

### DIFF
--- a/data/projects/aionui.yaml
+++ b/data/projects/aionui.yaml
@@ -1,0 +1,11 @@
+name: AionUi
+repo: https://github.com/iOfficeAI/AionUi
+homepage: https://www.aionui.com
+tagline: Free, open-source multi-agent desktop client that gives OpenCode (and other CLIs) a GUI.
+description: Cross-platform (macOS/Windows/Linux) desktop app that wraps OpenCode and other agent CLIs in a chat-based GUI. Supports any API key and multiple LLM providers with API-key polling, multi-session and multi-agent workflows, MCP and ACP protocols, file management and preview, code diff view, scheduled tasks, local data storage, and remote WebUI access.
+tags:
+  - gui
+  - desktop
+  - client
+  - multi-agent
+  - cross-platform


### PR DESCRIPTION
Adds **AionUi** to `data/projects/` — a free, open-source, cross-platform (macOS/Windows/Linux) multi-agent desktop client that gives OpenCode a chat-based GUI.

## Entry
- `data/projects/aionui.yaml`

## Why it fits
AionUi wraps OpenCode (and other agent CLIs) in a desktop GUI — sitting alongside existing GUI/desktop clients in Projects like CodeWalk, Deck, and OpenChamber. It adds multi-session/multi-agent workflows, multiple LLM providers with API-key polling, MCP + ACP protocol support, file management/preview, code diff view, scheduled tasks, local data storage, and remote WebUI access.

All descriptions reflect features AionUi actually ships today.

- Repo: https://github.com/iOfficeAI/AionUi
- Site: https://www.aionui.com

Ran `npm run validate` locally — all 219 files pass, including the new entry.