### PR TITLE
feat: add opencode-lazy-load plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,15 @@
 </details>
 
 <details>
+  <summary><b>opencode-lazy-load</b> <img src="https://badgen.net/github/stars/jijoyo/opencode-lazy-load" height="14"/> - <i>MCP token optimization - 88-90% savings</i></summary>
+  <blockquote>
+    Strips ALL MCP tool definitions from LLM requests. The LLM only sees load_tool as a callable tool. 3-layer defense: HTTP interception + SSE redirect + pointer list. 7 ALWAYS_VISIBLE core tools (bash, read, edit, write, task, glob, grep) work directly without loading.
+    <br><br>
+    <a href="https://github.com/jijoyo/opencode-lazy-load">🔗 <b>View Repository</b></a>
+  </blockquote>
+</details>
+
+<details>
   <summary><b>Ejentum</b> <img src="https://badgen.net/github/stars/ejentum/ejentum-mcp" height="14"/> - <i>MCP server with reasoning, code, anti-deception, and memory tools for AI agents</i></summary>
   <blockquote>
     MCP server with four tools (harness_reasoning, harness_code, harness_anti_deception, harness_memory) that AI agents can call on demand. Each tool returns a structured prompt the calling agent ingests before generating.

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@
 </details>
 
 <details>
-  <summary><b>opencode-lazy-load</b> <img src="https://badgen.net/github/stars/jijoyo/opencode-lazy-load" height="14"/> - <i>MCP token optimization - 88-90% savings</i></summary>
+  <summary><b>opencode-lazy-load</b> <img src="https://badgen.net/github/stars/jijoyo/opencode-lazy-load" height="14"/> - <i>Reduces MCP token overhead 88-90% via HTTP interception - 3 layer defense</i></summary>
   <blockquote>
     Strips ALL MCP tool definitions from LLM requests. The LLM only sees load_tool as a callable tool. 3-layer defense: HTTP interception + SSE redirect + pointer list. 7 ALWAYS_VISIBLE core tools (bash, read, edit, write, task, glob, grep) work directly without loading.
     <br><br>

--- a/data/plugins/opencode-lazy-load.yaml
+++ b/data/plugins/opencode-lazy-load.yaml
@@ -1,4 +1,4 @@
 name: opencode-lazy-load
 repo: https://github.com/jijoyo/opencode-lazy-load
-tagline: MCP token optimization - 88-90% savings
+tagline: Reduces MCP token overhead 88-90% via HTTP interception - 3 layer defense
 description: Strips ALL MCP tool definitions from LLM requests. The LLM only sees load_tool as a callable tool. 3-layer defense: HTTP interception + SSE redirect + pointer list. 7 ALWAYS_VISIBLE core tools (bash, read, edit, write, task, glob, grep) work directly without loading.

--- a/data/plugins/opencode-lazy-load.yaml
+++ b/data/plugins/opencode-lazy-load.yaml
@@ -1,0 +1,4 @@
+name: opencode-lazy-load
+repo: https://github.com/jijoyo/opencode-lazy-load
+tagline: MCP token optimization - 88-90% savings
+description: Strips ALL MCP tool definitions from LLM requests. The LLM only sees load_tool as a callable tool. 3-layer defense: HTTP interception + SSE redirect + pointer list. 7 ALWAYS_VISIBLE core tools (bash, read, edit, write, task, glob, grep) work directly without loading.


### PR DESCRIPTION
## What

Adds opencode-lazy-load to the curated list.

## Why

This plugin reduces MCP tool token overhead by 88-90% through HTTP body interception and on-demand tool loading. It uses a 3-layer defense approach:

1. **HTTP Body Interception**: Strips all tools except load_tool + 7 ALWAYS_VISIBLE core tools
2. **SSE Transform**: Redirects direct MCP calls to load_tool
3. **Pointer List**: load_tool description lists all available tools

## Results

| Metric | Before | After |
|--------|--------|-------|
| Tools visible to LLM | ~113 (13 built-in + ~100 MCP) | 20 (load_tool + 7 ALWAYS_VISIBLE + 12 built-in) |
| Token overhead | ~40-70k | ~6-8k |
| Savings | - | ~88-90% |
| MCP servers connected | 9 | 9 (still active) |

## Features

- **ALWAYS_VISIBLE**: 7 core tools (bash, read, edit, write, task, glob, grep) always available
- **__list__**: List all available tools (built-in + MCP)
- **3-layer defense**: Mechanical enforcement, not prompt-based

## Link

https://github.com/jijoyo/opencode-lazy-load