### PR TITLE
docs: add Agent Teams project

### DIFF
--- a/data/projects/agent-teams.yaml
+++ b/data/projects/agent-teams.yaml
@@ -1,4 +1,11 @@
-name: Agent Teams
+name: Agent Teams AI
 repo: https://github.com/777genius/agent-teams-ai
-tagline: Desktop control plane for autonomous OpenCode agent teams
-description: Run and coordinate OpenCode agents from a local desktop app with Kanban tasks, inter-agent messaging, code review, logs, and approval workflows. Also supports Claude Code, Codex, Cursor, and 200+ models across 75+ providers.
+tagline: Multi-team control plane for OpenCode and other coding agents
+description: Open-source orchestration platform for autonomous coding-agent teams with first-class OpenCode support. Agents manage Kanban tasks, message each other, review work, and coordinate across teams while users steer with high-level commands. Also supports Codex, Claude Code, Cursor, Grok, GitHub Copilot, Kiro, and other providers.
+homepage: https://agentteams.live/
+tags:
+  - multi-agent
+  - opencode
+  - orchestration
+  - kanban
+  - code-review

--- a/data/projects/agent-teams.yaml
+++ b/data/projects/agent-teams.yaml
@@ -1,0 +1,4 @@
+name: Agent Teams
+repo: https://github.com/777genius/agent-teams-ai
+tagline: Desktop control plane for autonomous OpenCode agent teams
+description: Run and coordinate OpenCode agents from a local desktop app with Kanban tasks, inter-agent messaging, code review, logs, and approval workflows. Also supports Claude Code, Codex, Cursor, and 200+ models across 75+ providers.


### PR DESCRIPTION
## Submission Type

- [ ] Plugin
- [x] Project
- [ ] Theme
- [ ] Agent
- [ ] Resource

## Details

**Name:** Agent Teams AI
**Repository:** https://github.com/777genius/agent-teams-ai
**Tagline:** Multi-team control plane for OpenCode and other coding agents

## Checklist

- [x] Relevant to OpenCode
- [x] Repository is public and accessible
- [x] Actively maintained
- [x] Not a duplicate
- [x] YAML file in the correct folder
- [x] Filename is kebab-case

## Why it fits

Agent Teams AI supports OpenCode as a first-class agent runtime and adds a platform-neutral workflow for coordinating autonomous coding-agent teams through Kanban tasks, inter-agent messaging, peer review, logs, approvals, and multi-team collaboration.

## Validation

- npm run validate -- data/projects/agent-teams.yaml
- git diff --check

Disclosure: I maintain Agent Teams AI.