### PR TITLE
docs: add opencode-todo-progress to plugins

### DIFF
--- a/data/plugins/opencode-todo-progress.yaml
+++ b/data/plugins/opencode-todo-progress.yaml
@@ -1,0 +1,4 @@
+name: opencode Todo Progress
+repo: https://github.com/satas20/opencode-todo-progress
+tagline: Persistent todo progress bar for the opencode TUI, shown next to the model name.
+description: Shows a compact progress indicator on the session prompt's agent/model row that updates live as todos are created and completed. Amber while in progress, green when done, and hidden when there are no todos. Installable via npm (opencode-todo-progress).

--- a/data/plugins/opencode-todo-progress.yaml
+++ b/data/plugins/opencode-todo-progress.yaml
@@ -1,4 +1,4 @@
-name: opencode Todo Progress
+name: OpenCode Todo Progress
 repo: https://github.com/satas20/opencode-todo-progress
-tagline: Persistent todo progress bar for the opencode TUI, shown next to the model name.
+tagline: Persistent todo progress bar for the OpenCode TUI, shown next to the model name.
 description: Shows a compact progress indicator on the session prompt's agent/model row that updates live as todos are created and completed. Amber while in progress, green when done, and hidden when there are no todos. Installable via npm (opencode-todo-progress).


### PR DESCRIPTION
Adds **opencode-todo-progress** to the plugins list.

A persistent todo progress bar for the opencode TUI. It shows a compact `▓▓▓▓▓▓▓▓░░ 3/10 · current task` indicator on the session prompt's agent/model row, next to the model name. It updates live as todos are created/completed and hides entirely when there are no todos.

- Repo: https://github.com/satas20/opencode-todo-progress
- npm: https://www.npmjs.com/package/opencode-todo-progress

### Checklist
- [x] Relevant to opencode
- [x] Public repository
- [x] Maintained (recent commits)
- [x] Unique (no existing entry)
- [x] Complete YAML fields

---

> ℹ️ **Reopens #511.** The original PR was auto-closed when my fork (`satas20/awesome-opencode`) was accidentally deleted. This PR contains the identical change; the new fork has been recreated with the same name. Please refer to #511 for the original review history.