### PR TITLE
docs: add oya to plugins

### DIFF
--- a/data/plugins/oya.yaml
+++ b/data/plugins/oya.yaml
@@ -1,0 +1,4 @@
+name: Oya
+repo: https://github.com/OyaAIProd/oya-plugins
+tagline: Build, deploy, and manage Oya AI agents and skills from OpenCode via the Oya MCP server.
+description: Adds Oya tools to OpenCode through the @oyadotai/opencode-plugin npm package. Create and deploy Oya agents (instructions, skills, routines, knowledge) to a sandboxed cloud runtime, schedule routines, connect gateways like Slack and Gmail, trigger runs, and inspect traces, all without leaving the editor. Requires a free Oya account and API key.


### PR DESCRIPTION
Adds Oya to the plugins list.

Oya ([@oyadotai/opencode-plugin](https://www.npmjs.com/package/@oyadotai/opencode-plugin)) lets OpenCode build, deploy, and manage Oya AI agents: create agents with skills and scheduled routines, deploy them to a sandboxed cloud runtime, connect gateways (Slack, Gmail, LinkedIn, and more), trigger runs, and inspect traces via the Oya MCP server.

- Public repo: https://github.com/OyaAIProd/oya-plugins (plugin lives in `opencode/`)
- Published on npm as `@oyadotai/opencode-plugin` (v0.3.0), MIT licensed, active commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)