### PR TITLE
docs: add UIZZE project

### DIFF
--- a/data/projects/uizze.yaml
+++ b/data/projects/uizze.yaml
@@ -1,4 +1,4 @@
 name: UIZZE
 repo: https://github.com/uizze/uizze
-tagline: Deterministic UI slop gate for OpenCode via MCP
-description: Help OpenCode avoid generic UI with 800,000+ real web and iOS screens, an anti-UI-slop agent skill, and a free MCP preview at https://uizze.com/mcp/preview.
+tagline: UI quality workflow for OpenCode with an optional authenticated MCP
+description: Help OpenCode avoid generic UI with a free anti-UI-slop Agent Skill and an optional authenticated UIZZE MCP for focused UI references from 800,000+ real web and iOS screens.

--- a/data/projects/uizze.yaml
+++ b/data/projects/uizze.yaml
@@ -1,0 +1,4 @@
+name: UIZZE
+repo: https://github.com/uizze/uizze
+tagline: Deterministic UI slop gate for OpenCode via MCP
+description: Help OpenCode avoid generic UI with 800,000+ real web and iOS screens, an anti-UI-slop agent skill, and a free MCP preview at https://uizze.com/mcp/preview.


### PR DESCRIPTION
## What does this PR add?

- Adds UIZZE to the Projects directory.
- UIZZE is usable from OpenCode through its MCP support and its free local anti-ui-slop Skill.

## Entry details

- Public source: https://github.com/uizze/uizze
- Free install: `npx skills add https://uizze.com --skill anti-ui-slop`
- Optional authenticated MCP: https://uizze.com/mcp
- The entry uses the canonical 800,000+ real web and iOS UI reference language.