### PR TITLE
docs: add opencode-sudo-popup to plugins

### DIFF
--- a/data/plugins/opencode-sudo-popup.yaml
+++ b/data/plugins/opencode-sudo-popup.yaml
@@ -1,0 +1,4 @@
+name: opencode-sudo-popup
+repo: https://github.com/uvindusl/opencode-sudo-popup
+tagline: Desktop GUI popup showing the exact sudo command before you authenticate
+description: Shows a compact, native GNOME (GTK4/libadwaita) popup when opencode needs root access, displaying the exact command it's about to run so you can review and approve it — no more stopping tasks mid-work to run sudo manually.


### PR DESCRIPTION
## Submission Type

- [x] Plugin
- [ ] Project
- [ ] Theme
- [ ] Agent
- [ ] Resource

## Details

**Name: Opencode Sudo PopUp** 
**Repository: https://github.com/uvindusl/opencode-sudo-popup** 
**Tagline:** 

## Checklist

- [x] Relevant to OpenCode
- [x] Repository is public and accessible
- [x] Actively maintained
- [x] Not a duplicate
- [x] YAML file in correct folder (`data/{category}/`)
- [x] Filename is kebab-case (e.g., `my-plugin.yaml`)

## YAML Format

Create a file in `data/{plugin}/opencode-sudo-popup.yaml`:

```yaml
name: opencode-sudo-popup
repo: https://github.com/uvindusl/opencode-sudo-popup
tagline: Desktop GUI popup showing the exact sudo command before you authenticate
description: Shows a compact, native GNOME (GTK4/libadwaita) popup when opencode needs root access, displaying the exact command it's about to run so you can review and approve it — no more stopping tasks mid-work to run sudo manually.
```

