### PR TITLE
docs: add TelegramCode to projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -2039,9 +2039,9 @@ template (cowork-with-github). Install: drag-and-drop .plugin into Cowork.
 </details>
 
 <details>
-  <summary><b>TelegramCode</b> <img src="https://badgen.net/github/stars/olosegres/telegramcode" height="14"/> - <i>Telegram bot for OpenCode and Claude Code, one topic per project</i></summary>
+  <summary><b>TelegramCode</b> <img src="https://badgen.net/github/stars/olosegres/telegramcode" height="14"/> - <i>Telegram bot for OpenCode and Claude Code, run coding agents from your phone</i></summary>
   <blockquote>
-    Run OpenCode or Claude Code on your own box and drive it from Telegram, by voice or text. Every forum topic is its own project session, so it feels like terminal tabs on your phone. Self-hosted, MIT.
+    Run your coding agents on your own machine or VPS and drive them from Telegram, by voice or text. Each forum topic is its own project session, like terminal tabs on your phone. Self-hosted, no open ports, MIT.
     <br><br>
     <a href="https://github.com/olosegres/telegramcode">🔗 <b>View Repository</b></a>
   </blockquote>

--- a/README.md
+++ b/README.md
@@ -2039,6 +2039,15 @@ template (cowork-with-github). Install: drag-and-drop .plugin into Cowork.
 </details>
 
 <details>
+  <summary><b>TelegramCode</b> <img src="https://badgen.net/github/stars/olosegres/telegramcode" height="14"/> - <i>Telegram bot for OpenCode and Claude Code, one topic per project</i></summary>
+  <blockquote>
+    Run OpenCode or Claude Code on your own box and drive it from Telegram, by voice or text. Every forum topic is its own project session, so it feels like terminal tabs on your phone. Self-hosted, MIT.
+    <br><br>
+    <a href="https://github.com/olosegres/telegramcode">🔗 <b>View Repository</b></a>
+  </blockquote>
+</details>
+
+<details>
   <summary><b>Tokscale</b> <img src="https://badgen.net/github/stars/junhoyeo/tokscale" height="14"/> - <i>Token usage tracking CLI</i></summary>
   <blockquote>
     A CLI tool for tracking token usage from OpenCode and other coding agents (Claude Code, Codex, Gemini CLI, and Cursor IDE).

--- a/data/projects/telegramcode.yaml
+++ b/data/projects/telegramcode.yaml
@@ -1,9 +1,15 @@
 name: TelegramCode
 repo: https://github.com/olosegres/telegramcode
-tagline: Telegram bot for OpenCode and Claude Code, one topic per project
-description: Run OpenCode or Claude Code on your own box and drive it from Telegram, by voice or text. Every forum topic is its own project session, so it feels like terminal tabs on your phone. Self-hosted, MIT.
+tagline: Telegram bot for OpenCode and Claude Code, run coding agents from your phone
+description: Run your coding agents on your own machine or VPS and drive them from Telegram, by voice or text. Each forum topic is its own project session, like terminal tabs on your phone. Self-hosted, no open ports, MIT.
 tags:
   - telegram
-  - self-hosted
+  - telegram-bot
+  - coding-agent
+  - opencode
   - claude-code
+  - self-hosted
   - voice
+  - vps
+  - mobile
+  - remote-development

--- a/data/projects/telegramcode.yaml
+++ b/data/projects/telegramcode.yaml
@@ -1,0 +1,9 @@
+name: TelegramCode
+repo: https://github.com/olosegres/telegramcode
+tagline: Telegram bot for OpenCode and Claude Code, one topic per project
+description: Run OpenCode or Claude Code on your own box and drive it from Telegram, by voice or text. Every forum topic is its own project session, so it feels like terminal tabs on your phone. Self-hosted, MIT.
+tags:
+  - telegram
+  - self-hosted
+  - claude-code
+  - voice


### PR DESCRIPTION
## Submission Type

- [ ] Plugin
- [x] Project
- [ ] Theme
- [ ] Agent
- [ ] Resource

## Details

**Name:** TelegramCode
**Repository:** https://github.com/olosegres/telegramcode
**Tagline:** Telegram bot for OpenCode and Claude Code, run coding agents from your phone

Run and monitor remote coding sessions from your phone: both OpenCode and Claude Code, one forum topic per project (topics act like terminal tabs). Voice input, file intake, scheduled prompts, and sessions that survive restarts. Public since early 2026, MIT.

## Checklist

- [x] Relevant to OpenCode
- [x] Repository is public and accessible
- [x] Actively maintained
- [x] Not a duplicate
- [x] YAML file in correct folder (`data/{category}/`)
- [x] Filename is kebab-case (e.g., `my-plugin.yaml`)

## YAML Format

Created `data/projects/telegramcode.yaml`, then ran `npm run validate` and `npm run generate`:

```yaml
name: TelegramCode
repo: https://github.com/olosegres/telegramcode
tagline: Telegram bot for OpenCode and Claude Code, run coding agents from your phone
description: Run your coding agents on your own machine or VPS and drive them from Telegram, by voice or text. Each forum topic is its own project session, like terminal tabs on your phone. Self-hosted, no open ports, MIT.
tags:
  - telegram
  - telegram-bot
  - coding-agent
  - opencode
  - claude-code
  - self-hosted
  - voice
  - vps
  - mobile
  - remote-development
```

See [contributing.md](contributing.md) for full instructions.
